### PR TITLE
add new module for google translate widget

### DIFF
--- a/components/google-translate/index.js
+++ b/components/google-translate/index.js
@@ -1,0 +1,51 @@
+class CAGOVGoogleTranslate extends window.HTMLElement {  
+  connectedCallback() {
+    this.storagekey = 'google_translate_page_used';
+
+    this.innerHTML = `<div class="quarter standard-translate d-none" id="google_translate_element">
+      <a class="goog-init" href="#">Change language</a>
+    </div>`;
+
+    this.querySelector('.goog-init').addEventListener('click', function (e) {
+      e.preventDefault();
+      sessionStorage.setItem(this.storagekey, new Date().getTime());
+      this.innerHTML = '<div class="quarter standard-translate" id="google_translate_element">loading</div>';
+      this.loadGoogleTranslateJS();
+    }.bind(this));
+
+    this.loadGoogleTranslateJS();
+  }
+
+  loadGoogleTranslateJS() {
+    if (sessionStorage.getItem(this.storagekey)) {	
+      this.appendGoogleTranslateJS();
+    } else {
+      this.querySelector('.standard-translate').classList.remove('d-none');
+    }
+  }
+
+  appendGoogleTranslateJS() {
+    const JS = document.createElement('script');
+    JS.type = 'text/javascript';
+    JS.defer = 'defer';
+    JS.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    document.body.appendChild(JS);
+  }
+}
+window.customElements.define('cagov-google-translate', CAGOVGoogleTranslate);
+
+
+// global callback function for google translate javascript load
+window.googleTranslateElementInit = function() {
+  let translateEl = document.getElementById('google_translate_element');
+  translateEl.innerHTML = '';
+  translateEl.classList.remove('d-none');
+  new google
+    .translate
+    .TranslateElement({
+      pageLanguage: "en",
+      gaTrack: !0,
+      autoDisplay: !1,
+      layout: google.translate.TranslateElement.InlineLayout.VERTICAL
+    }, 'google_translate_element');
+}

--- a/components/google-translate/package.json
+++ b/components/google-translate/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@cagov/ds-google-translate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/components/google-translate/readme.md
+++ b/components/google-translate/readme.md
@@ -1,0 +1,5 @@
+# Google translate widget load on click
+
+This custom element renders a link that when clicked places the google site translate widget into the element. This is setup this way because the google translate javascript is used rarely and slows down all page loads when loaded by default. This module uses a sessionStorage parameter to remember if the translate widget was activated and to load it automatically if it was previously.
+
+This is used in the header of state sites like <a href="https://headless.cannabis.ca.gov">https://headless.cannabis.ca.gov</a>


### PR DESCRIPTION
New web component created to load the google translate widget but in a delayed fashion

- Load the component immediately if it had been clicked before
- If the component had not been loaded present a link to "change language"
- Keep track if the component had been clicked with a sessionStorage variable