### PR TITLE
Rename ofiicial-logo to official-logo

### DIFF
--- a/components/statewide-header/CHANGELOG.md
+++ b/components/statewide-header/CHANGELOG.md
@@ -2,3 +2,5 @@
 `ds-statewide-header`
 # 1.0.5
 * Removed -15px padding left from the .official-header selector since we we don't need that padding anymore because we removed header-container with its padding properties from the base css.
+# 1.0.6
+* Renamed .ofiicial-logo to .official-logo. Should help prevent naming conflicts within existing markup.

--- a/components/statewide-header/index.css
+++ b/components/statewide-header/index.css
@@ -28,12 +28,12 @@
   margin: 0 auto;
   padding: 0 10px 0 10px;
 }
-.official-header .ofiicial-logo {
+.official-header .official-logo {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
 }
-.official-header .ofiicial-logo .cagov-logo {
+.official-header .official-logo .cagov-logo {
   margin: 0 20px 0 0;
   display: flex;
 }

--- a/components/statewide-header/package-lock.json
+++ b/components/statewide-header/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cagov-ds-statewide-header",
+  "name": "@cagov/ds-statewide-header",
   "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cagov-ds-statewide-header",
+      "name": "@cagov/ds-statewide-header",
       "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {

--- a/components/statewide-header/package.json
+++ b/components/statewide-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.css",
   "scripts": {

--- a/components/statewide-header/readme.md
+++ b/components/statewide-header/readme.md
@@ -11,7 +11,7 @@ This CSS only module contains the styles required to create the list of steps in
 ```
 <div class="official-header">
   <div class="container">
-    <div class="ofiicial-logo">
+    <div class="official-logo">
       <a class="cagov-logo" href="https://ca.gov" title="ca.gov" target="_blank" rel="noopener">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
             y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"

--- a/components/statewide-header/src/index.scss
+++ b/components/statewide-header/src/index.scss
@@ -27,7 +27,7 @@
         padding: 0 10px 0 10px;
     }
   
-    .ofiicial-logo {
+    .official-logo {
         display: flex;
         flex-wrap: wrap;
         align-items: center;

--- a/components/statewide-header/template.html
+++ b/components/statewide-header/template.html
@@ -1,6 +1,6 @@
 <div class="official-header">
   <div class="container">
-    <div class="ofiicial-logo">
+    <div class="official-logo">
       <a class="cagov-logo" href="https://ca.gov" title="ca.gov" target="_blank" rel="noopener">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
             y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"


### PR DESCRIPTION
Per #120, this is a simple fix within ds-statewide-header to rename `.ofiicial-logo` to `.official-logo`.

I'll put in a separate PR to make the corresponding markup change in the headless.cannabis.ca.gov project.

This is my first PR to design-system, so let me know if I've missed any process or changes.