### PR TITLE
removed sticky property since it is causing target scroll positioning issues

### DIFF
--- a/components/content-navigation/CHANGELOG.md
+++ b/components/content-navigation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG for ds-content-navigation
 `ds-content-navigation`
+# 1.0.5
+* Removed sticky position since it caused scroll to target positioning bug.
 # 1.0.4
 * Made content navigation sticky (Request came from cannabis project issue #234). To do: need to highlight nav items based on the h2 # or section, which user is scrolling through.
 # 1.0.3

--- a/components/content-navigation/package.json
+++ b/components/content-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-content-navigation",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/components/content-navigation/src/index.scss
+++ b/components/content-navigation/src/index.scss
@@ -51,11 +51,3 @@ sidebar cagov-content-navigation ul li {
     line-height: 24px;
   }
 }
-
-/* sticky content navigation in desktop */
-@media (min-width: 768px) {
-  .sidebar-container {
-    position: sticky;
-    top: 200px;
-  }
-}


### PR DESCRIPTION
This will fix this bug:
https://github.com/cagov/cannabis.ca.gov/issues/394