### PR TITLE
Added padding right 24px to the cagov-logo #162

### DIFF
--- a/components/statewide-footer/CHANGELOG.md
+++ b/components/statewide-footer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ds-statewide-footer
 `ds-statewide-footer`
+
+
+# 1.0.4
+* Added padding right 24px to the cagov-logo to make there is always consistent space between footer-secondary-links and cagov-logo.
 # 1.0.3
 * Updated statewide footer container's padding to 16px instead of 1rem to make it consistent with other components.
 # 1.0.2

--- a/components/statewide-footer/index.css
+++ b/components/statewide-footer/index.css
@@ -39,7 +39,7 @@ footer .bg-light-grey svg .gov {
   fill: var(--cagov-primary-dark, #003484);
 }
 footer .cagov-logo {
-  padding: 0 0 0 0;
+  padding: 0 24px 0 0;
 }
 footer .bg-light-grey a,
 footer .copyright {

--- a/components/statewide-footer/package-lock.json
+++ b/components/statewide-footer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov-ds-statewide-footer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov-ds-statewide-footer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "devDependencies": {
         "sass": "^1.37.5"

--- a/components/statewide-footer/package.json
+++ b/components/statewide-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-statewide-footer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.css",
   "scripts": {

--- a/components/statewide-footer/src/index.scss
+++ b/components/statewide-footer/src/index.scss
@@ -45,7 +45,7 @@ footer {
 	}
 
 	.cagov-logo {
-		padding: 0 0 0 0;
+		padding: 0 24px 0 0;
 	}
 
 	.bg-light-grey a,


### PR DESCRIPTION
This issue came up in drought site (even though it looks good in cannabis). THis PR will fix it and make it consistent for all websites.
![Screen Shot 2021-10-14 at 2 16 22 PM](https://user-images.githubusercontent.com/31669748/137397663-4321cafc-578c-4c5b-a920-01ff24d463e5.png)

