### PR TITLE
changed content navigation's border color to gray-300 #165

### DIFF
--- a/components/content-navigation/CHANGELOG.md
+++ b/components/content-navigation/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for ds-content-navigation
 `ds-content-navigation`
+
+# 1.0.6
+* Changed content navigation border color to Gray-300.
 # 1.0.5
 * Removed sticky position since it caused scroll to target positioning bug.
 # 1.0.4

--- a/components/content-navigation/package.json
+++ b/components/content-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-content-navigation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/components/content-navigation/src/index.scss
+++ b/components/content-navigation/src/index.scss
@@ -21,11 +21,11 @@ sidebar cagov-content-navigation ul li {
   padding-bottom: 18px;
   margin-top: 0px;
   margin-bottom: 0px;
-  border-bottom: 1px solid var(--gray-200, #ededef);
+  border-bottom: 1px solid var(--gray-300, #e1e0e3);
   line-height: 28.2px;
   list-style: none;
   &:first-child {
-    border-top: 1px solid var(--gray-200, #ededef);
+    border-top: 1px solid var(--gray-300, #e1e0e3);
   }
 
   a {


### PR DESCRIPTION
Currently content navigation border is using gray 200. Change it to Gray 300 (#e1e0e3)
![Screen Shot 2021-10-18 at 4 27 46 PM](https://user-images.githubusercontent.com/31669748/138005253-95aea1fb-2a9e-4943-9ad6-ae2f316aace2.png)
