### PR TITLE
M1slow

### DIFF
--- a/components/menu/test/index.js
+++ b/components/menu/test/index.js
@@ -4,8 +4,8 @@ import { expect, fixture } from '@open-wc/testing';
 
 import '../src/index.js';
 
-describe('<cagov-navoverlay>', function() {
-  this.timeout(5000)
+describe('<cagov-navoverlay>', function () {
+  this.timeout(5000);
   it('works', async () => {
     const csslink = document.createElement('link');
     csslink.rel = 'stylesheet';


### PR DESCRIPTION
The test required to run by the pre commit hook is failing on M1 macs probably due to unoptimized native library

It passes on an M1 if we give it 4x as much time to execute

We reproduced the failure on a couple M1 macs, works fine everywhere else.