### PR TITLE
Fix up width in ds-external-link-icon

### DIFF
--- a/components/combined-css/dist/cagov.css
+++ b/components/combined-css/dist/cagov.css
@@ -3555,7 +3555,7 @@ sidebar cagov-content-navigation ul li a:hover {
   left: 1px;
   top: -2px;
   text-decoration: none;
-  min-width: 0.85rem;
+  width: 0.8em;
 }
 .external-link-icon svg path {
   fill: var(--primary-color, #004abc);

--- a/components/combined-css/dist/cannabis.css
+++ b/components/combined-css/dist/cannabis.css
@@ -3555,7 +3555,7 @@ sidebar cagov-content-navigation ul li a:hover {
   left: 1px;
   top: -2px;
   text-decoration: none;
-  min-width: 0.85rem;
+  width: 0.8em;
 }
 .external-link-icon svg path {
   fill: var(--primary-color, #004abc);

--- a/components/combined-css/dist/drought.css
+++ b/components/combined-css/dist/drought.css
@@ -3555,7 +3555,7 @@ sidebar cagov-content-navigation ul li a:hover {
   left: 1px;
   top: -2px;
   text-decoration: none;
-  min-width: 0.85rem;
+  width: 0.8em;
 }
 .external-link-icon svg path {
   fill: var(--primary-color, #004abc);

--- a/components/external-link-icon/CHANGELOG.md
+++ b/components/external-link-icon/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG for ds-external-link-icon
 `ds-external-link-icon`
 
+# 1.0.3
+* Change min-width to regular width.
+* Change width unit from rem to em, so it'll grow and shrink relative to surrounding text.
+
 # 1.0.2
 * Linted and formatted code per root eslint/prettier settings.
 * Added unit test.

--- a/components/external-link-icon/index.css
+++ b/components/external-link-icon/index.css
@@ -6,7 +6,7 @@
   left: 1px;
   top: -2px;
   text-decoration: none;
-  min-width: 0.85rem;
+  width: 0.8em;
 }
 .external-link-icon svg path {
   fill: var(--primary-color, #004abc);

--- a/components/external-link-icon/package-lock.json
+++ b/components/external-link-icon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-external-link-icon",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-external-link-icon",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.0-next.2",

--- a/components/external-link-icon/package.json
+++ b/components/external-link-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-external-link-icon",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.css",
   "scripts": {

--- a/components/external-link-icon/src/index.scss
+++ b/components/external-link-icon/src/index.scss
@@ -7,7 +7,7 @@
   left: 1px;
   top: -2px;
   text-decoration: none;
-  min-width: 0.85rem;
+  width: 0.8em;
   svg path {
     fill: var(--primary-color, #004abc);
   }


### PR DESCRIPTION
We recently discovered a problem with ds-external-link-icon in Firefox. The icons appear enormous.

![image](https://user-images.githubusercontent.com/1208960/140971222-bccc975b-757a-4dd3-b682-9d9d8d80683c.png)

The reason: Firefox will not honor a `min-width` or `max-width` that's applied to an **inline-block** element. This does not appear to be a Firefox bug; I think it's a deliberate decision on Mozilla's part. The fix for this is to just use a regular `width` instead. That's what's in this PR.

I've also changed the width's unit from `rem` to `em`, to help the icon grow and shrink with the size of the surrounding text.