### PR TITLE
Fix h3 reset in ds-feature-card

### DIFF
--- a/components/combined-css/dist/cagov.css
+++ b/components/combined-css/dist/cagov.css
@@ -3621,14 +3621,13 @@ svg ~ .external-link-icon,
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {
@@ -3754,14 +3753,13 @@ h3 {
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {

--- a/components/combined-css/dist/cannabis.css
+++ b/components/combined-css/dist/cannabis.css
@@ -3621,14 +3621,13 @@ svg ~ .external-link-icon,
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {
@@ -3754,14 +3753,13 @@ h3 {
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {

--- a/components/combined-css/dist/drought.css
+++ b/components/combined-css/dist/drought.css
@@ -3621,14 +3621,13 @@ svg ~ .external-link-icon,
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {
@@ -3754,14 +3753,13 @@ h3 {
   text-decoration: none;
 }
 
-/* reset */
-h3 {
-  margin: 0;
-}
-
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
   padding-bottom: 16px;
+}
+
+.cagov-featured-section h3 {
+  margin: 0;
 }
 
 .cagov-hero-body-content p {

--- a/components/feature-card/CHANGELOG.md
+++ b/components/feature-card/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG for ds-feature-card
 `ds-feature-card`
 
+# 1.0.5
+* Limit the h3 definition to .cagov-featured-section, so it doesn't reset all h3 across the site.
+
 # 1.0.4
 * Linted and formatted code per root eslint/prettier settings.
 * Added unit test.

--- a/components/feature-card/package.json
+++ b/components/feature-card/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@cagov/ds-feature-card",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "This is a design for featuring important content at the top of a page. The layout uses a sidebar pattern with the text elements: header, description and call to action button on the left and an image on the right. On smaller screens the image appears above the text.",
-  "main": "index.css",  "type": "module",
+  "main": "index.css",  
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/cagov/design-system/tree/main/components/feature-card"

--- a/components/feature-card/src/index.scss
+++ b/components/feature-card/src/index.scss
@@ -32,13 +32,12 @@
 .no-deco {
 	text-decoration: none;
 }
-/* reset */
-h3 {
-	margin: 0;
-}
 /* spacing overrides, can these come from base-css? */
 .cagov-featured-section h2 {
 	padding-bottom: 16px;
+}
+.cagov-featured-section h3 {
+	margin: 0;
 }
 .cagov-hero-body-content p {
 	margin-bottom: 16px;


### PR DESCRIPTION
This PR addresses a problem we discovered within ds-feature-card. The current h3 definition in that component resets h3 margins across the entire site. (If this is desired behavior, we should probably move this to ds-base-css.) 

This fix limits that h3 rule to just ds-feature-card.