### PR TITLE
Fix component permalinks

### DIFF
--- a/components/components.11tydata.js
+++ b/components/components.11tydata.js
@@ -8,6 +8,9 @@ module.exports = {
     // componentSlug gets the folder name for the page's component.
     componentSlug: (article) =>
       article.page.filePathStem.match(/\/components\/(.+?)\/.+/)[1],
+    // Need to ensure the permalink is always lower-case, even though some docs are not.
+    permalink: (article) =>
+      `${article.page.filePathStem.toLowerCase()}/index.html`,
     // The `has` object checks to see if the component has various .md files.
     has: (article) => {
       const pattern = `components/${article.componentSlug}/*.md`;


### PR DESCRIPTION
Throughout our component markdown files, some filenames are capitalized and some are lower-cased. This doesn't matter with local builds, but it's breaking some links on S3/Cloudfront. This fix will ensure all component documents will be available at lower-cased URLs.

We can remove it if we rename all of our component documents into a consistent standard.