### PR TITLE
Build principles from data

### DIFF
--- a/docs/pages/principles.md
+++ b/docs/pages/principles.md
@@ -1,75 +1,23 @@
+{%- from "macros/principles-page-item.njk" import principlesPageItem -%}
+
 # Principles
 
 We’ve researched the needs of Californians and created these principles to help state departments create great websites, services, and products.
 
-## Design for people’s needs
+{{ principlesPageItem(principles, 1) }}
 
-Put the needs of Californians first in everything you do. Make your guiding question, “What does someone need to do?”
+{{ principlesPageItem(principles, 2) }}
 
-> *Example*
->
-> The per page feedback component makes it easy to learn about the needs of your audience.
+{{ principlesPageItem(principles, 3) }}
 
-## Do the hard work to make it simple and elegant
+{{ principlesPageItem(principles, 4) }}
 
-Government services often put the burden on people to understand and navigate services and policies. Break down these barriers for them to create simple, understandable services.
+{{ principlesPageItem(principles, 5) }}
 
-> *Example*
->
-> The step list component takes complicated processes and makes their steps transparent.
+{{ principlesPageItem(principles, 6) }}
 
-## Prioritize accessibility
+{{ principlesPageItem(principles, 7) }}
 
-Make your services accessible for all Californians. Think about people who have been traditionally excluded, like people who use screen readers or reside in low bandwidth regions.
+{{ principlesPageItem(principles, 8) }}
 
-> *Example*
->
-> Our visual design style guide includes direction on how to create accessible design. All design system components are WCAG 2.1 compliant.
-
-## Be concise
-
-Things are easy to use when they’re simple. Ask yourself, “Does this word, image, or functionality help people do what they need to do?”
-
-> *Example*
->
-> Our content design guidelines provide actionable tips for writing in plain language. This makes information to the point and easy to read.
-
-## Design with data
-
-Use research and analytics to understand how people use your services and products. This keeps us focused on their needs, not preconceived solutions.
-
-> *Example*
->
-> Design System components work seamlessly with Google Analytics. This gathers information about the people who use your services and their needs.
-
-## Iterate, then iterate again
-
-Services and products are never finished. Rigorously test and refine your work to make sure it’s robust and useful.
-
-> *Example*
->
-> We continuously look at data and improve Design System components. Our Alpha, Beta, and Production labels show what development track each component is in.
-
-## Be consistent, but not uniform
-
-Use the component, content, and visual guidelines. This creates a shared, consistent experience across state departments.
-
-> *Example*
->
-> The statewide header is a default component of the Design System. This helps people know they are on a CA.gov website.
-
-## Optimize performance
-
-Not every Californian has a high-end device. When you build services and products, think about people on a range of devices and internet speeds.
-
-> *Example*
->
-> Websites built with the design system have a Lighthouse performance score X% higher than the average CA.gov website. 
-
-## Make things open
-As part of our commitment to transparency and collaboration, our default state is to share. OurDesign System work is open to the public.
-
-> *Example*
->
-> All of the Design System code is open source and hosted on Github. This means anyone can see how it's built, suggest improvements, or adapt it for their own purposes.
-
+{{ principlesPageItem(principles, 9) }}

--- a/docs/site/_data/principles.json
+++ b/docs/site/_data/principles.json
@@ -1,0 +1,47 @@
+{
+  "1": {
+    "name": "Design for people's needs",
+    "description": "Put the needs of Californians first in everything you do. Make your guiding question, “What does someone need to do?”",
+    "example": "The <a href='/components/feedback/readme/'>per page feedback component</a> makes it easy to learn about the needs of your audience."
+  },
+  "2": {
+    "name": "Do the hard work to make it simple and elegant",
+    "description": "Government services often put the burden on people to understand and navigate services and policies. Break down these barriers for them to create simple, understandable services.",
+    "example": "The <a href='/components/step-list/readme/'>step list component</a> takes complicated processes and makes their steps transparent."
+  },
+  "3": {
+    "name": "Prioritize accessibility",
+    "description": "Make your services accessible for all Californians. Think about people who have been traditionally excluded, like people who use screen readers or reside in low bandwidth regions.",
+    "example": "Our <a href='/style/design/'>visual design style guide</a> includes direction on how to create accessible design. All design system components are <a href='https://www.w3.org/TR/WCAG21/'>WCAG 2.1 compliant</a>."
+  },
+  "4": {
+    "name": "Be concise",
+    "description": "Things are easy to use when they’re simple. Ask yourself, “Does this word, image, or functionality help people do what they need to do?”",
+    "example": "Our <a href='/style/content/'>content design guidelines</a> provide actionable tips for writing in plain language. This makes information to the point and easy to read."
+  },
+  "5": {
+    "name": "Design with data",
+    "description": "Use research and analytics to understand how people use your services and products. This keeps us focused on their needs, not preconceived solutions.",
+    "example": "Design System components work seamlessly with Google Analytics. This gathers information about the people who use your services and their needs."
+  },
+  "6": {
+    "name": "Iterate, then iterate again",
+    "description": "Services and products are never finished. Rigorously test and refine your work to make sure it’s robust and useful.",
+    "example": "We continuously look at data and improve Design System components. Our Alpha, Beta, and Production labels show what development track each component is in."
+  },
+  "7": {
+    "name": "Be consistent, but not uniform",
+    "description": "Use the component, content, and visual guidelines. This creates a shared, consistent experience across state departments.",
+    "example": "The <a href='/components/statewide-header/readme/'>statewide header</a> is a default component of the Design System. This helps people know they are on a CA.gov website."
+  },
+  "8": {
+    "name": "Optimize performance",
+    "description": "Not every Californian has a high-end device. When you build services and products, think about people on a range of devices and internet speeds.",
+    "example": "Websites built with the design system have a Lighthouse performance score X% higher than the average CA.gov website."
+  },
+  "9": {
+    "name": "Make things open",
+    "description": "As part of our commitment to transparency and collaboration, our default state is to share. Our Design System work is open to the public.",
+    "example": "All of the <a href='https://github.com/cagov/design-system'>Design System code</a> is open source and hosted on <a href='https://github.com'>Github</a>. This means anyone can see how it's built, suggest improvements, or adapt it for their own purposes."
+  }
+}

--- a/docs/site/_includes/macros/principles-page-item.njk
+++ b/docs/site/_includes/macros/principles-page-item.njk
@@ -1,0 +1,12 @@
+{% macro principlesPageItem(principles, number) %}
+  {% set principle = principles[number] %}
+  <section class="principle-page-item">
+    <h2>{{ principle.name }}</h2>
+    <h3>Principle {{ number }}</h3>
+    <p>{{ principle.description | safe }}</p>
+    <blockquote>
+      <p><em>Example</em></p>
+      <p>{{ principle.example | safe }}</p>
+    </blockquote>
+  </section>
+{% endmacro %}

--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -40,7 +40,7 @@
       <img src="/img/library-sketch.svg" alt="sketch of control panel" />
     </div>
     <div class="cagov-card-body">
-      <a href="" class="cagov-section-highlight">Component library</a>
+      <a href="/components/" class="cagov-section-highlight">Component library</a>
       <p>You do not have to reinvent the wheel every time you need a digital solution. Our components solve common user needs for you.</p>
     </div>
   </div>
@@ -87,6 +87,9 @@
   </div>
 </div>
 
+{% set principleNumber = range(1, 9) | random %}
+{% set principle = principles[principleNumber] %}
+
 <div>
   <cagov-highlight-section>
     <article role="article" class="full-bleed bg-highlight-lightest">
@@ -99,11 +102,11 @@
             <img src="https://california.azureedge.net/cdt/statetemplate/5.6.0/images/color.png" alt="highlight section demo"/>
           </div>
           <div class="highlight-text">
-            <h3>Prioritize accessibility</h3>
-            <h4 class="mt-0">Principle 3</h4>
-            <p>Make your services accessible for all Californians. Think about people who have been traditionally excluded, like people who use screen readers or reside in low bandwidth regions.</p>
+            <h3>{{ principle.name }}</h3>
+            <h4 class="mt-0">Principle {{ principleNumber }}</h4>
+            <p>{{ principle.description }}</p>
             <div class="wp-button">
-              <a class="btn-primary-outline">See all the principles</a>
+              <a class="btn-primary-outline" href="/principles/">See all the principles</a>
             </div>
           </div>
         </section>

--- a/docs/src/css/sass/ds-site-global.scss
+++ b/docs/src/css/sass/ds-site-global.scss
@@ -24,6 +24,7 @@
 }
 .entry-content blockquote {
   padding: 1rem;
+  margin-bottom: calc(1rem + var(--ratio));
   background-color: var(--primary-lightest-color, #B3C9EB);
 }
 .entry-content blockquote p:last-child {


### PR DESCRIPTION
This PR moves content regarding our principles into a data file, from which we can build the principles page AND fill in the featured principle card on the homepage.

The featured principle card on the homepage is currently random. It will refresh with each site build. 

Might be good to get some design input for the principles page. It feels special enough that we should dress it up a bit.