### PR TITLE
Improve code blocks

### DIFF
--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -4,7 +4,7 @@ The accordion element allows for sections of text to be expanded or collapsed on
 
 ## Install
 
-```html preview
+```html
 <script type="module" src="/builds/accordion-esm.js"></script>
 ```
 

--- a/docs/src/11ty/markdown.js
+++ b/docs/src/11ty/markdown.js
@@ -7,46 +7,120 @@ const md = markdownIt({
   linkify: true,
 });
 
-const preWrap = (html) => `<pre><code class="hljs">${html}</code></pre>`;
-const scriptWrap = (js) => `<script type="module">${js}</script>`;
-const previewWrap = (html) => `<div class="code-block-preview">${html}</div>`;
+/**
+ * Encloses syntax-highlighted code blocks in <pre> and <code> tags.
+ * @param {String} hljsHtml
+ * An HTML string that's formatted by highlight.js.
+ * @returns {String} HTML
+ */
+const preWrap = (hljsHtml) =>
+  `<pre><code class="hljs">${hljsHtml}</code></pre>`;
 
+/**
+ * Displays the code block's language alongside the code.
+ * @param {String} hljsHtml
+ * An HTML string that's formatted by highlight.js.
+ * @param {String} language
+ * The code block's language.
+ * @returns {String} HTML
+ */
+const codeWrap = (hljsHtml, language) => `
+  <div class="code-block">
+    <p class="code-block-language">
+      ${language}
+    </p>
+    ${preWrap(hljsHtml)}
+  </div>
+`;
+
+/**
+ * HTML that both displays and executes a JS code block.
+ * @param {String} js
+ * A Javascript code block.
+ * @param {String} hljsHtml
+ * An HTML string that's formatted by highlight.js.
+ * @returns {String} HTML
+ */
+const scriptWrap = (js, hljsHtml) => `
+  <script type="module">
+    ${js}
+  </script>
+  ${codeWrap(hljsHtml, 'Javascript')}
+`;
+
+/**
+ * HTML that both displays and demonstrates an HTML mark-up block.
+ * @param {String} rawHtml
+ * An HTML string that's NOT YET formatted by highlight.js.
+ * @param {String} hljsHtml
+ * The same HTML string that's formatted by highlight.js.
+ * @returns {String} HTML
+ */
+const previewWrap = (rawHtml, hljsHtml) => `
+  <div class="code-preview">
+    <div class="code-preview-demo">
+      ${rawHtml}
+    </div>
+    ${codeWrap(hljsHtml, 'HTML')}
+  </div>
+`;
+
+/**
+ * A default fallback for code blocks that break highlight.js.
+ * This ensures the Markdown will still render.
+ * @param {String} code
+ * @returns {String} HTML
+ */
 const defaultWrap = (code) => {
   const escapedCode = md.utils.escapeHtml(code);
   return preWrap(escapedCode);
 };
 
+// Here we override the default "fence" rule of markdown-it.
+// This is where we tell our markdown engine to format code.
+// https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
 md.renderer.rules.fence = (tokens, idx) => {
   const token = tokens[idx];
+
+  // info is the list of meta/labels supplied with the code block in markdown.
   const info = token.info ? md.utils.unescapeAll(token.info).trim() : '';
   const [lang, instruction] = info.split(/\s+/g);
 
+  // This is the raw code block as supplied in the markdown.
   const rawCode = token.content;
-  let formattedCode;
 
+  // If markdown supplies a language, try to highlight syntax.
   if (lang) {
     try {
       const hljsOptions = {
         language: lang,
         ignoreIllegals: true,
       };
+
+      // Apply syntax highlighting.
       const highlightedCode = hljs.highlight(rawCode, hljsOptions).value;
-      formattedCode = preWrap(highlightedCode);
+
+      // This is a special JS preview block.
+      if (instruction === 'script') {
+        return scriptWrap(rawCode, highlightedCode);
+      }
+
+      // This is a special HTML demo block.
+      if (instruction === 'preview') {
+        return previewWrap(rawCode, highlightedCode);
+      }
+
+      // Remove the XML blurb when it's HTML. Highlight.js wrinkle.
+      const languageName =
+        lang.toLowerCase() === 'html' ? 'HTML' : hljs.getLanguage(lang).name;
+
+      return codeWrap(highlightedCode, languageName);
     } catch (_) {
-      formattedCode = defaultWrap(rawCode);
+      return defaultWrap(rawCode);
     }
-
-    if (instruction === 'script') {
-      formattedCode = scriptWrap(rawCode) + formattedCode;
-    }
-
-    if (instruction === 'preview') {
-      formattedCode = previewWrap(rawCode) + formattedCode;
-    }
-
-    return formattedCode;
   }
 
+  // Syntax highlighting is not possible, so just return a regular code block.
   return defaultWrap(rawCode);
 };
 

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -170,3 +170,36 @@
     row-gap: 1.5rem;
   }
 }
+
+.code-preview {
+  border: solid 1px #A09FA7;
+  background-color: #f9f9fa;
+  padding: 1rem;
+  &-demo {
+    border: solid 1px #A09FA7;
+    background-color: white;
+    padding: 1rem;
+  }
+  .code-block {
+    margin-bottom: 0;
+  }
+}
+
+.code-block {
+  margin: 1rem 0;
+  &-language {
+    background-color: #2b2b2b;
+    color: #A09FA7;
+    border-bottom: solid 1px #A09FA7;
+    font-style: italic;
+    margin: 0;
+    padding: .5rem 1rem;
+  }
+  code.hljs {
+    margin: 0;
+  }
+}
+
+code.hljs {
+  border-radius: 0;
+}

--- a/docs/src/js/index.js
+++ b/docs/src/js/index.js
@@ -3,4 +3,5 @@ import '../../../components/menu/src/index.js';
 import '../../../components/content-navigation/src/index.js';
 import '../../../components/plus/index.js';
 import '../../../components/minus/index.js';
+import '../../../components/accordion/dist/index.js';
 import './component-sidebar.js';


### PR DESCRIPTION
This PR improves the markdown code previews in a few ways.

* Adds a language label above the code block.
* Hopefully clarifies what's happening in the previews by enclosing it in a box with the relevant code snippet, at least a little.
* Code is better organized and documented.

Open to suggestion here.

<img width="827" alt="Screen Shot 2022-01-05 at 16 43 24" src="https://user-images.githubusercontent.com/1208960/148310370-4a52b8d2-e451-4560-864f-520eb3e2eb41.png">