### PR TITLE
add dynamic html writing script to accordion

### DIFF
--- a/components/accordion/CHANGELOG.md
+++ b/components/accordion/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 `ds-accordion`
 
+#1.0.9
+* Add prepublish hook which writes latest sample HTML into readme from template.html
+* Update description to match latest design system docs
 # 1.0.8
 * Linted and formatted code per root eslint/prettier settings.
 * Added unit test.

--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -11,7 +11,7 @@ The accordion element allows for sections of text to be expanded or collapsed on
 # Demo
 
 <!-- the value inside the htmlpreview tags is written dynamically from the template file using a prepublish hook to keep the sample in synch with the tested HTML -->
-<htmlpreview>
+<html-preview>
   ```html preview
     <cagov-accordion>
     <div class="cagov-accordion-card">
@@ -235,7 +235,7 @@ The accordion element allows for sections of text to be expanded or collapsed on
     </div>
   </cagov-accordion>
   ```
-  </htmlpreview>
+  </html-preview>
 
 ## Specs
 

--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -10,6 +10,7 @@ The accordion element allows for sections of text to be expanded or collapsed on
 
 # Demo
 
+<!-- the value inside the htmlpreview tags is written dynamically from the template file using a prepublish hook to keep the sample in synch with the tested HTML -->
 <htmlpreview>
   ```html preview
     <cagov-accordion>

--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -10,29 +10,231 @@ The accordion element allows for sections of text to be expanded or collapsed on
 
 # Demo
 
-```html preview
-<cagov-accordion>
-  <div class="cagov-accordion-card">
-    <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
-      <div class="accordion-title">Lorem ipsum</div>
-      <div class="plus-minus">
-        <cagov-plus></cagov-plus>
-        <cagov-minus></cagov-minus>
-      </div>
-    </button>
-    <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
-      <div class="card-body">
-        <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
-          moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
-          Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
-          shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
-          proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
-          aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+<htmlpreview>
+  ```html preview
+    <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
       </div>
     </div>
-  </div>
-</cagov-accordion>
-```
+  </cagov-accordion>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+  ```
+  </htmlpreview>
 
 ## Specs
 

--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@cagov/ds-accordion",
-  "version": "1.0.8",
-  "description": "This custom element recreates the bootstrap accordion component functionality without the jquery dependency.",
+  "version": "1.0.9",
+  "description": "Accordions are expandable sections of content. Each section contains a heading (H2 or H3), a plus button (+), and more body text when opened.",
   "main": "dist/index.js",
   "scripts": {
-    "test": "web-test-runner \"test/**/*.js\" --node-resolve",
-    "test:visual": "web-test-runner \"test/**/*.js\" --node-resolve --config test-config.js",
     "build:js": "rollup --config rollup.config.js",
-    "build": "npm run build:js && sass src/index.scss src/css/index.css"
+    "build": "npm run build:js && sass src/index.scss src/css/index.css",
+    "html:preview": "node ../../docs/src/publish/dynamic-html.js",
+    "prepublishOnly": "npm run html:preview",
+   "test": "web-test-runner \"test/**/*.js\" --node-resolve",
+    "test:visual": "web-test-runner \"test/**/*.js\" --node-resolve --config test-config.js"
   },
   "repository": {
     "type": "git",

--- a/components/base-css/preview.html
+++ b/components/base-css/preview.html
@@ -21,9 +21,9 @@
     </script>
     <link id="theme-stylesheet" rel="stylesheet" href="dist/themes/drought.css">
 
-    <link type="text/css" rel="stylesheet" href="../card-grid/index.css">
+    <link type="text/css" rel="stylesheet" href="../button-grid/index.css">
     <link type="text/css" rel="stylesheet" href="../step-list/index.css">
-    <link type="text/css" rel="stylesheet" href="../menu/dist/_style.css">
+    <link type="text/css" rel="stylesheet" href="../menu/index.css">
     <style>
       .hidden-search,
       .sr-only {
@@ -56,7 +56,7 @@
 
       <h2>Featured cards</h2>
 
-      <div id="card-grid-html-content"></div>
+      <div id="button-grid-html-content"></div>
 
       <h2>Accordion</h2>
 
@@ -93,9 +93,9 @@
       fetch('../menu/template.html')
         .then(response => response.text())
         .then((string) => { document.getElementById('menu-html-content').innerHTML = string; });
-      fetch('../card-grid/template.html')
+      fetch('../button-grid/template.html')
         .then(response => response.text())
-        .then((string) => { document.getElementById('card-grid-html-content').innerHTML = string; });
+        .then((string) => { document.getElementById('button-grid-html-content').innerHTML = string; });
       fetch('../accordion/template.html')
         .then(response => response.text())
         .then((string) => { document.getElementById('accordion-html-content').innerHTML = string; });

--- a/docs/src/publish/dynamic-html.js
+++ b/docs/src/publish/dynamic-html.js
@@ -5,16 +5,16 @@ const htmlFile = './template.html';
 try {
   let readme = fs.readFileSync(readmeFile, 'utf8');
 
-  let retrievalRegex = /<htmlpreview>(.|\n)*?<\/htmlpreview>/;
+  let retrievalRegex = /<html-preview>(.|\n)*?<\/html-preview>/;
 
   let latestHTML = fs.readFileSync(htmlFile,'utf8');
   const markdownCodeDelim = '```';
 
-  let finalReadme = readme.replace(retrievalRegex,`<htmlpreview>
+  let finalReadme = readme.replace(retrievalRegex,`<html-preview>
   ${markdownCodeDelim}html preview
   ${latestHTML}
   ${markdownCodeDelim}
-  </htmlpreview>`);
+  </html-preview>`);
 
   fs.writeFileSync(readmeFile,finalReadme,'utf8')
 } catch(e) {

--- a/docs/src/publish/dynamic-html.js
+++ b/docs/src/publish/dynamic-html.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const readmeFile = './readme.md';
+const htmlFile = './template.html';
+
+try {
+  let readme = fs.readFileSync(readmeFile, 'utf8');
+
+  let retrievalRegex = /<htmlpreview>(.|\n)*?<\/htmlpreview>/;
+
+  let latestHTML = fs.readFileSync(htmlFile,'utf8');
+  const markdownCodeDelim = '```';
+
+  let finalReadme = readme.replace(retrievalRegex,`<htmlpreview>
+  ${markdownCodeDelim}html preview
+  ${latestHTML}
+  ${markdownCodeDelim}
+  </htmlpreview>`);
+
+  fs.writeFileSync(readmeFile,finalReadme,'utf8')
+} catch(e) {
+  console.log(e);
+  // called from prepublish, exit if readme cannot be updated
+  process.exit(1);
+}


### PR DESCRIPTION
This is an example of a process to keep the HTML samples in the readmes in synch with the HTML used when this component is tested. Please suggest improvements.

- Adds prepublish hook that runs new script
- Adds preset tag to readme around sample html so it can be retrieved
- Script gets latest HTML from template.html and writes it into the readme in the desired location
- readme.md and template.html filename values are hardcoded in script (not optimal)

Discussed this with @xjensen a bit and running the script at this point seems good because it will ensure browsable docs on npm get updated. The format: html preview is used after the markdown code delimiters because this is expected by the design system docs site and is used to display both a live preview using the HTML as well as a visible code block.

