### PR TITLE
Fix load-code-block-from-file previews

### DIFF
--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -12,44 +12,8 @@ The accordion element allows for sections of text to be expanded or collapsed on
 
 <!-- the value inside the htmlpreview tags is written dynamically from the template file using a prepublish hook to keep the sample in synch with the tested HTML -->
 <html-preview>
-  ```html preview
-    <cagov-accordion>
-    <div class="cagov-accordion-card">
-      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
-        <div class="accordion-title">Lorem ipsum</div>
-        <div class="plus-minus">
-          <cagov-plus>
-            <div class="accordion-icon" aria-hidden="true">
-              <svg viewbox="0 0 25 25">
-                <title>Plus</title>
-                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
-                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
-              </svg>
-            </div>
-          </cagov-plus>
-          <cagov-minus>
-            <div class="accordion-icon" aria-hidden="true">
-              <svg viewbox="0 0 25 25">
-                <title>Minus</title>
-                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
-              </svg>
-            </div>
-          </cagov-minus>
-        </div>
-      </button>
-      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
-        <div class="card-body">
-          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
-            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
-            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
-            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
-            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
-            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
-        </div>
-      </div>
-    </div>
-  </cagov-accordion>
 
+```html preview
   <cagov-accordion>
     <div class="cagov-accordion-card">
       <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
@@ -234,8 +198,46 @@ The accordion element allows for sections of text to be expanded or collapsed on
       </div>
     </div>
   </cagov-accordion>
-  ```
-  </html-preview>
+
+  <cagov-accordion>
+    <div class="cagov-accordion-card">
+      <button class="accordion-card-header accordion-alpha" type="button" aria-expanded="false">
+        <div class="accordion-title">Lorem ipsum</div>
+        <div class="plus-minus">
+          <cagov-plus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Plus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+                <line y1="6" x1="12.5" y2="19" x2="12.5" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-plus>
+          <cagov-minus>
+            <div class="accordion-icon" aria-hidden="true">
+              <svg viewbox="0 0 25 25">
+                <title>Minus</title>
+                <line x1="6" y1="12.5" x2="19" y2="12.5"  fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+              </svg>
+            </div>
+          </cagov-minus>
+        </div>
+      </button>
+      <div class="accordion-card-container" aria-hidden=" true" style="height: 0px;">
+        <div class="card-body">
+          <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf
+            moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
+            Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
+            shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
+            proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim
+            aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
+        </div>
+      </div>
+    </div>
+  </cagov-accordion>
+```
+
+</html-preview>
 
 ## Specs
 

--- a/docs/src/publish/dynamic-html.js
+++ b/docs/src/publish/dynamic-html.js
@@ -1,23 +1,29 @@
 const fs = require('fs');
+
 const readmeFile = './readme.md';
 const htmlFile = './template.html';
 
 try {
-  let readme = fs.readFileSync(readmeFile, 'utf8');
+  const readme = fs.readFileSync(readmeFile, 'utf8');
 
-  let retrievalRegex = /<html-preview>(.|\n)*?<\/html-preview>/;
+  const retrievalRegex = /<html-preview>(.|\n)*?<\/html-preview>/;
 
-  let latestHTML = fs.readFileSync(htmlFile,'utf8');
+  const latestHTML = fs.readFileSync(htmlFile, 'utf8');
   const markdownCodeDelim = '```';
 
-  let finalReadme = readme.replace(retrievalRegex,`<html-preview>
-  ${markdownCodeDelim}html preview
-  ${latestHTML}
-  ${markdownCodeDelim}
-  </html-preview>`);
+  const finalReadme = readme.replace(
+    retrievalRegex,
+    `<html-preview>
 
-  fs.writeFileSync(readmeFile,finalReadme,'utf8')
-} catch(e) {
+${markdownCodeDelim}html preview
+${latestHTML}
+${markdownCodeDelim}
+
+</html-preview>`,
+  );
+
+  fs.writeFileSync(readmeFile, finalReadme, 'utf8');
+} catch (e) {
   console.log(e);
   // called from prepublish, exit if readme cannot be updated
   process.exit(1);


### PR DESCRIPTION
This is a quick fix to ensure compatibility between markdown code previews on the site, and insert-html-into-readme-file script on the back end. 

I was running into this scenario where markdown was not rendering the code block. 

<img width="850" alt="Screen Shot 2022-01-10 at 14 23 52" src="https://user-images.githubusercontent.com/1208960/148849642-9bbc439c-241a-4474-a9db-d58f681c74a7.png">

This happens because markdown really wants the code block delimiter (` ``` `) to be flush with the left margin of the document, no leading spaces. There should also be a new-line between the `<html-preview>` tags and the code-block delimiters. With these changes, everything looks fine, even if it leaves the code a bit uglier.

The other changes to the code all come from the linter.
