### PR TITLE
add visual design style guide page and 11ty 1.0

### DIFF
--- a/docs/pages/style/design.md
+++ b/docs/pages/style/design.md
@@ -1,1 +1,149 @@
-# Design Style Guide
+# Visual Design
+
+We are consistent without being uniform. Below are the guidelines that allow us to achieve this.
+
+## Color
+
+We don’t dictate which colors should be used so that we allow every agency to maintain their unique character, but we have the following system to ensure  consistency across websites. 
+
+It consists of 3 base colors. Each base color has three variations. These variations are designed to offer flexibility while ensuring a consistent, visually pleasing, and accessible look.
+
+In respect to accessibility, color choice is intended to align with Web Content Accessibility Guideline (WCAG) 2.1 Level AA which requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text and a  contrast ratio of at least 3:1 for graphics and user interface components.
+
+<span class="cagov-table">
+  <table width="100%">
+    <tr>
+      <th>Base Color</th><th>Dark</th><th>Light</th><th>Very Light</th>
+    </tr>
+    <tr>
+      <td>Primary color</td><td>30% shade</td><td>30% tint</td><td>70% tint</td>
+    </tr>
+    <tr>
+      <td>Secondary color</td><td>30% shade</td><td>30% tint</td><td>70% tint</td>
+    </tr>
+    <tr>
+      <td>Highlight color</td><td>30% shade</td><td>30% tint</td><td>70% tint</td>
+    </tr>
+  </table>
+</span>
+
+For CA.gov, that looks like this. This is also the default color palette for any new digital service.
+
+While there is no official color palette for CA.gov, the primary, secondary and highlight color are selected to reflect the latest CA.gov initiatives such as covid19.ca.gov and alpha.ca.gov. 
+<style>
+  .cagov-table table {
+    width: 100%;
+  }
+  .cagov-table table.partial-borders {
+    border-bottom: none;
+    border-right: none;
+  }
+  .bgcolor-chips td {
+    height: 5rem;
+  }
+  .font-demo {
+    border: solid 1px #ccc;
+    padding: 2rem;
+    display: inline-block;
+    margin-bottom: 2rem;
+  }
+</style>
+<span class="cagov-table">
+  <table>
+    <tr>
+      <th>Base Color</th><th>Dark</th><th>Light</th><th>Very Light</th>
+    </tr>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #004ABC;"></td><td style="background-color: #003484;"></td><td style="background-color: #4d80d0;"></td><td style="background-color: #b3c9eb;"></td>
+    </tr>
+    <tr>
+      <td>Primary color: #004ABC</td><td>30% shade: #003484</td><td>30% tint: #4d80d0</td><td>70% tint: #b3c9eb</td>
+    </tr>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #FF8000;"></td><td style="background-color: #b35a00;"></td><td style="background-color: #ffa64d;"></td><td style="background-color: #ffd9b3;"></td>
+    </tr>
+    <tr>
+      <td>Secondary color: #FF8000</td><td>30% shade: #b35a00</td><td>30% tint: #ffa64d</td><td>70% tint: #ffd9b3</td>
+    </tr>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #FEC02F;"></td><td style="background-color: #b28621;"></td><td style="background-color: #fed36d;"></td><td style="background-color: #ffecc1;"></td>
+    </tr>
+    <tr>
+      <td>Highlight color: #FEC02F</td><td>30% shade: #b28621</td><td>30% tint: #fed36d</td><td>70% tint: #ffecc1</td>
+    </tr>
+  </table>
+</span>
+
+In addition to the 3 colors above, we standardize colors used for global UI elements such as notifications.
+
+<span class="cagov-table">
+  <table class="partial-borders">
+    <tr class="bgcolor-chips">
+      <td style="background-color: #FFFFFF;"></td><td style="background-color: #F9F9FA;"></td><td style="background-color: #E1E0E3;"></td><td style="background-color: #D3D2D6;"></td>
+    </tr>
+    <tr>
+      <td>White:<br>#FFFFFF</td><td>Gray 100: #F9F9FA</td><td>Gray 300: #E1E0E3</td><td>Gray 400: #D3D2D6</td>
+    </tr>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #C4C3CB;"></td><td style="background-color: #B3B3B8;"></td><td style="background-color: #A09FA7;"></td><td style="background-color: #6C6B77;"></td>
+    </tr>
+    <tr>
+      <td>Gray 500: #C4C3CB</td><td>Gray 600: #B3B3B8</td><td>Gray 700: #A09FA7</td><td>Gray 800: #6C6B77</td>
+    </tr>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #3F3E4D;"></td><td style="background-color: #000000;"></td>
+    </tr>
+    <tr>
+      <td>Gray 900: #3F3E4D</td><td>Black:<br>#000000</td>
+    </tr>
+  </table>
+</span>
+
+<span class="cagov-table">
+  <table>
+    <tr class="bgcolor-chips">
+      <td style="background-color: #008542;"></td><td style="background-color: #B71234;"></td><td style="background-color: #ffd700;"></td><td style="background-color: #000080;"></td>
+    </tr>
+    <tr>
+      <td>Success:<br>#008542</td><td>Danger:<br>#B71234</td><td>Warning:<br>#ffd700</td><td>Info:<br>#000080</td>
+    </tr>
+  </table>
+</span>
+
+## Typography
+
+### Public Sans
+
+<div class="font-demo">
+  <div style="font-size: 6.75rem;">Aa</div>
+  <p>A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p>a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p>0 1 2 3 4 5 6 7 8 9</p>
+</div>
+
+We use Public Sans, a strong, neutral typeface for interfaces, text, and headings, which was designed by the USWDS.
+
+Our base font size is 18px with a line spacing of 32px. To generate the rest of the values, we use the golden ratio (1.6) as a guide.
+
+## Images
+
+We use photos and illustrations for communicating information. We adhere to the following guidelines.
+- Avoid using images as unnecessary decoration.
+- All images should be 3:2 unless their proportions have significance. 
+- Use alt text whenever adding images.
+
+## Icons
+
+We currently use icons from the State Web Template. You can read more about them here.
+
+## Accessibility
+
+Design plays a critical role in ensuring that our digital services are accessible. In practice, this means:
+- Ensure sufficient contrast between text and its background.
+- Don’t use color as the only visual means of conveying information.
+- Provide visual focus indication for keyboard focus.
+- Don’t make people hover to find things.
+- Clear and descriptive labels for forms and navigation
+- Feedback that’s easy to identify and understand 
+- Create responsive design
+- Headings and subheadings for a more meaningful text

--- a/docs/pages/style/design.md
+++ b/docs/pages/style/design.md
@@ -30,24 +30,7 @@ In respect to accessibility, color choice is intended to align with Web Content 
 For CA.gov, that looks like this. This is also the default color palette for any new digital service.
 
 While there is no official color palette for CA.gov, the primary, secondary and highlight color are selected to reflect the latest CA.gov initiatives such as covid19.ca.gov and alpha.ca.gov. 
-<style>
-  .cagov-table table {
-    width: 100%;
-  }
-  .cagov-table table.partial-borders {
-    border-bottom: none;
-    border-right: none;
-  }
-  .bgcolor-chips td {
-    height: 5rem;
-  }
-  .font-demo {
-    border: solid 1px #ccc;
-    padding: 2rem;
-    display: inline-block;
-    margin-bottom: 2rem;
-  }
-</style>
+
 <span class="cagov-table">
   <table>
     <tr>

--- a/docs/src/css/sass/design-guide-page.scss
+++ b/docs/src/css/sass/design-guide-page.scss
@@ -1,0 +1,16 @@
+.cagov-table table {
+  width: 100%;
+}
+.cagov-table table.partial-borders {
+  border-bottom: none;
+  border-right: none;
+}
+.bgcolor-chips td {
+  height: 5rem;
+}
+.font-demo {
+  border: solid 1px #ccc;
+  padding: 2rem;
+  display: inline-block;
+  margin-bottom: 2rem;
+}

--- a/docs/src/css/sass/index.scss
+++ b/docs/src/css/sass/index.scss
@@ -14,6 +14,7 @@
 @import '../../../../components/link-icon/src/index.scss';
 @import '../../../../components/skip-to-content/src/index.scss';
 @import '../../../../components/back-to-top/src/index.scss';
+@import '../../../../components/table/src/index.scss';
 
 /* NAVIGATION ELEMENTS */
 @import '../../../../components/statewide-header/src/index.scss';

--- a/docs/src/css/sass/index.scss
+++ b/docs/src/css/sass/index.scss
@@ -42,5 +42,5 @@
 /* Used on the principles page to display each principle */
 @import './principles-page';
 
-
-
+/* Used on the visual design style guide page to for table and font demo styles */
+@import './design-guide-page';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "./components/*"
       ],
       "dependencies": {
-        "@11ty/eleventy": "^1.0.0-beta.3",
+        "@11ty/eleventy": "^1.0.0",
         "@cagov/11ty-build-system": "^0.3.0",
         "cheerio": "^1.0.0-rc.10",
         "cross-env": "^7.0.3",
@@ -35,7 +35,7 @@
     },
     "components/accordion": {
       "name": "@cagov/ds-accordion",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -67,7 +67,7 @@
     },
     "components/base-css": {
       "name": "@cagov/ds-base-css",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -304,7 +304,7 @@
     },
     "components/step-list": {
       "name": "@cagov/ds-step-list",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -328,28 +328,29 @@
       "integrity": "sha512-tYrGX3Tvccufy2jaYDkYpjBmVP1LeQq6b/d0r4GYThTXL4f3ZR7yMAl/0r8h9xvnsP+gkO53wfnV7s8cXcCtEg=="
     },
     "node_modules/@11ty/eleventy": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0-beta.8.tgz",
-      "integrity": "sha512-oW83KmXtRB8oCGSYCEesTaWZFt7Vl9aa0L+ulzrtFDEYzFRQfvRkZdLrAnHptnh6jeOOJ5TRRdJ+eJUKbExd7w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0.tgz",
+      "integrity": "sha512-UMZghkMFwovu3Vh6DzjJ9GbcBnlE3nydGmLAti2AB1d6etQE+jXgfuHNxOyV1em33ywsBgGUCtLmLHaaTSU+Nw==",
       "dependencies": {
         "@11ty/dependency-tree": "^2.0.0",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
         "browser-sync": "^2.27.7",
-        "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "dependency-graph": "^0.11.0",
         "ejs": "^3.1.6",
-        "fast-glob": "^3.2.7",
+        "fast-glob": "^3.2.9",
+        "graceful-fs": "^4.2.9",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
-        "liquidjs": "^9.28.5",
+        "kleur": "^4.1.4 ",
+        "liquidjs": "^9.32.0",
         "lodash": "^4.17.21",
-        "luxon": "^2.1.1",
-        "markdown-it": "^12.2.0",
+        "luxon": "^2.3.0",
+        "markdown-it": "^12.3.2",
         "minimist": "^1.2.5",
         "moo": "^0.5.1",
         "multimatch": "^5.0.0",
@@ -362,8 +363,7 @@
         "pug": "^3.0.2",
         "recursive-copy": "^2.0.13",
         "semver": "^7.3.5",
-        "slugify": "^1.6.2",
-        "time-require": "^0.1.2"
+        "slugify": "^1.6.5"
       },
       "bin": {
         "eleventy": "cmd.js"
@@ -374,6 +374,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@11ty/eleventy/node_modules/path-to-regexp": {
@@ -3241,14 +3257,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/date-time": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-      "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -4675,9 +4683,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4686,7 +4694,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5031,9 +5039,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -5133,14 +5141,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
       "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-    },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/has-cors": {
       "version": "1.1.0",
@@ -6087,6 +6087,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/koa": {
       "version": "2.13.4",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.4.tgz",
@@ -6237,9 +6245,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.29.0.tgz",
-      "integrity": "sha512-lnowf3fRcwjqaom8sQSImJeHWZS2974DFlMl8sTdlQX/P846MhK14C0oRGYHaXiDjJbhDzi0zKc1HB4y8hUArw==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.32.0.tgz",
+      "integrity": "sha512-Sy3WfHMZgI3VKQdkwjVOE9JIqe0AujnSbb6OFbH5FnpKruHC/byI7r4SiaVvKV+3CaidU1XudyM/gEEUBXVklg==",
       "bin": {
         "liquid": "bin/liquid.js",
         "liquidjs": "bin/liquid.js"
@@ -6445,9 +6453,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==",
       "engines": {
         "node": ">=12"
       }
@@ -6477,9 +6485,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.0.tgz",
-      "integrity": "sha512-T345UZZ6ejQWTjG6PSEHplzNy5m4kF6zvUpHVDv8Snl/pEU0OxIK0jGg8YLVNwJvT8E0YJC7/2UvssJDk/wQCQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -7040,14 +7048,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-      "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -7285,20 +7285,6 @@
         "condense-newlines": "^0.2.1",
         "extend-shallow": "^2.0.1",
         "js-beautify": "^1.6.12"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-      "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-      "dependencies": {
-        "parse-ms": "^0.1.0"
-      },
-      "bin": {
-        "pretty-ms": "cli.js"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -8473,9 +8459,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.4.tgz",
-      "integrity": "sha512-Pcz296CK0uGnTf4iNQId79Uv6/5G16t0g0x3OsxWS8qVSOW+JXNnNHKVcuDiMgEGTWyK6zjlWXo2dvzV/FLf9Q==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8863,7 +8849,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "node_modules/tfunk": {
       "version": "4.0.0",
@@ -8929,52 +8916,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "node_modules/time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dependencies": {
-        "chalk": "^0.4.0",
-        "date-time": "^0.1.1",
-        "pretty-ms": "^0.2.1",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/time-require/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/time-require/node_modules/chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/time-require/node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/to-array": {
       "version": "0.1.4",
@@ -9463,28 +9404,29 @@
       "integrity": "sha512-tYrGX3Tvccufy2jaYDkYpjBmVP1LeQq6b/d0r4GYThTXL4f3ZR7yMAl/0r8h9xvnsP+gkO53wfnV7s8cXcCtEg=="
     },
     "@11ty/eleventy": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0-beta.8.tgz",
-      "integrity": "sha512-oW83KmXtRB8oCGSYCEesTaWZFt7Vl9aa0L+ulzrtFDEYzFRQfvRkZdLrAnHptnh6jeOOJ5TRRdJ+eJUKbExd7w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0.tgz",
+      "integrity": "sha512-UMZghkMFwovu3Vh6DzjJ9GbcBnlE3nydGmLAti2AB1d6etQE+jXgfuHNxOyV1em33ywsBgGUCtLmLHaaTSU+Nw==",
       "requires": {
         "@11ty/dependency-tree": "^2.0.0",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
         "browser-sync": "^2.27.7",
-        "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "dependency-graph": "^0.11.0",
         "ejs": "^3.1.6",
-        "fast-glob": "^3.2.7",
+        "fast-glob": "^3.2.9",
+        "graceful-fs": "^4.2.9",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
-        "liquidjs": "^9.28.5",
+        "kleur": "^4.1.4 ",
+        "liquidjs": "^9.32.0",
         "lodash": "^4.17.21",
-        "luxon": "^2.1.1",
-        "markdown-it": "^12.2.0",
+        "luxon": "^2.3.0",
+        "markdown-it": "^12.3.2",
         "minimist": "^1.2.5",
         "moo": "^0.5.1",
         "multimatch": "^5.0.0",
@@ -9497,10 +9439,17 @@
         "pug": "^3.0.2",
         "recursive-copy": "^2.0.13",
         "semver": "^7.3.5",
-        "slugify": "^1.6.2",
-        "time-require": "^0.1.2"
+        "slugify": "^1.6.5"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "path-to-regexp": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
@@ -11924,11 +11873,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
       "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
     },
-    "date-time": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-      "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
-    },
     "debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -12976,9 +12920,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -13246,9 +13190,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -13328,11 +13272,6 @@
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-cors": {
       "version": "1.1.0",
@@ -14001,6 +13940,11 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+    },
     "koa": {
       "version": "2.13.4",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.4.tgz",
@@ -14140,9 +14084,9 @@
       }
     },
     "liquidjs": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.29.0.tgz",
-      "integrity": "sha512-lnowf3fRcwjqaom8sQSImJeHWZS2974DFlMl8sTdlQX/P846MhK14C0oRGYHaXiDjJbhDzi0zKc1HB4y8hUArw=="
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.32.0.tgz",
+      "integrity": "sha512-Sy3WfHMZgI3VKQdkwjVOE9JIqe0AujnSbb6OFbH5FnpKruHC/byI7r4SiaVvKV+3CaidU1XudyM/gEEUBXVklg=="
     },
     "lit": {
       "version": "2.0.2",
@@ -14306,9 +14250,9 @@
       }
     },
     "luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -14328,9 +14272,9 @@
       }
     },
     "markdown-it": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.0.tgz",
-      "integrity": "sha512-T345UZZ6ejQWTjG6PSEHplzNy5m4kF6zvUpHVDv8Snl/pEU0OxIK0jGg8YLVNwJvT8E0YJC7/2UvssJDk/wQCQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -14744,11 +14688,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-ms": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-      "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
-    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -14934,14 +14873,6 @@
         "condense-newlines": "^0.2.1",
         "extend-shallow": "^2.0.1",
         "js-beautify": "^1.6.12"
-      }
-    },
-    "pretty-ms": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-      "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-      "requires": {
-        "parse-ms": "^0.1.0"
       }
     },
     "progress": {
@@ -15842,9 +15773,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.4.tgz",
-      "integrity": "sha512-Pcz296CK0uGnTf4iNQId79Uv6/5G16t0g0x3OsxWS8qVSOW+JXNnNHKVcuDiMgEGTWyK6zjlWXo2dvzV/FLf9Q=="
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "socket.io": {
       "version": "2.4.0",
@@ -16163,7 +16094,8 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "tfunk": {
       "version": "4.0.0",
@@ -16216,39 +16148,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "requires": {
-        "chalk": "^0.4.0",
-        "date-time": "^0.1.1",
-        "pretty-ms": "^0.2.1",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
     },
     "to-array": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "site:watch:dev": "cross-env NODE_ENV=development eleventy --serve --incremental",
     "site:start": "npm run site:watch",
     "site:dev": "npm run site:watch:dev",
-    "build": "echo \"WARN: no build specified\" && exit 0" 
+    "build": "echo \"WARN: no build specified\" && exit 0"
   },
   "repository": {
     "type": "git",
@@ -54,7 +54,7 @@
     "./components/*"
   ],
   "dependencies": {
-    "@11ty/eleventy": "^1.0.0-beta.3",
+    "@11ty/eleventy": "^1.0.0",
     "@cagov/11ty-build-system": "^0.3.0",
     "cheerio": "^1.0.0-rc.10",
     "cross-env": "^7.0.3",


### PR DESCRIPTION

- Bumped 11ty to v1.0 release
- New page: Visual design style guide based on (hacked together with table tags in markdown):

<img width="196" alt="Screen Shot 2022-01-11 at 4 23 38 PM" src="https://user-images.githubusercontent.com/353360/149042095-4da8b985-fafb-47b2-ab53-1de077714f33.png">

