### PR TITLE
add cdn deploy publishing step

### DIFF
--- a/components/accordion/package-lock.json
+++ b/components/accordion/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-accordion",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-accordion",
-      "version": "1.0.6",
+      "version": "1.0.9",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",

--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "build:js": "rollup --config rollup.config.js",
     "build": "npm run build:js && sass src/index.scss src/css/index.css",
+    "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
-    "prepublishOnly": "npm run html:preview",
-   "test": "web-test-runner \"test/**/*.js\" --node-resolve",
+    "prepublishOnly": "npm run html:preview && npm run build && npm run cdn:publish",
+    "test": "web-test-runner \"test/**/*.js\" --node-resolve",
     "test:visual": "web-test-runner \"test/**/*.js\" --node-resolve --config test-config.js"
   },
   "repository": {

--- a/docs/src/publish/cdn-deploy.js
+++ b/docs/src/publish/cdn-deploy.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+
+// publish to  S3 bucket at /components/${package-name}/v${package-version}/
+let currentPackageInfo = JSON.parse(fs.readFileSync('./package.json','utf8'));
+const packageName = currentPackageInfo.name.replace('@cagov/','');
+const packageVersion = currentPackageInfo.version;
+const keyPrefix = `components/${packageName}/v${packageVersion}/dist/`;
+
+const directoryToUpload = process.cwd()+'/dist';
+const bucketName = 'cdn.designsystem.webstandards.ca.gov';
+
+// get file paths
+const filePaths = [];
+const getFilePaths = (dir) => {
+  fs.readdirSync(dir).forEach(function (name) {
+    const filePath = path.join(dir, name);
+    const stat = fs.statSync(filePath);
+    if (stat.isFile()) {
+      filePaths.push(filePath);
+    } else if (stat.isDirectory()) {
+      getFilePaths(filePath);
+    }
+  });
+};
+
+getFilePaths(directoryToUpload);
+
+// upload to S3
+const uploadToS3 = (dir, path) => {
+  return new Promise((resolve, reject) => {
+    const key = keyPrefix + path.split(`${dir}/`)[1];
+    const params = {
+      Bucket: bucketName,
+      Key: key,
+      Body: fs.readFileSync(path),
+    };
+    s3.putObject(params, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        console.log(`uploaded ${params.Key} to ${params.Bucket}`);
+        resolve(path);
+      }
+    });
+  });
+};
+
+const uploadPromises = filePaths.map((path) =>
+  uploadToS3(directoryToUpload, path)
+);
+Promise.all(uploadPromises)
+  .then((result) => {
+    console.log('uploads complete');
+    console.log(result);
+  })
+  .catch((err) => {
+    console.error(err);
+    // called from prepublish, exit if buid cannot be deployed to cdn which will stop npm publish
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@web/dev-server": "^0.1.17",
         "@web/test-runner": "^0.13.16",
         "@web/test-runner-puppeteer": "^0.10.1",
+        "aws-sdk": "^2.1055.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "husky": "^7.0.4",
@@ -35,7 +36,7 @@
     },
     "components/accordion": {
       "name": "@cagov/ds-accordion",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -67,7 +68,7 @@
     },
     "components/base-css": {
       "name": "@cagov/ds-base-css",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -106,7 +107,7 @@
     },
     "components/combined-css": {
       "name": "@cagov/ds-combined-css",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.0-next.2",
@@ -304,7 +305,7 @@
     },
     "components/step-list": {
       "name": "@cagov/ds-step-list",
-      "version": "1.0.2",
+      "version": "2.0.1",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -2195,6 +2196,43 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1055.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1055.0.tgz",
+      "integrity": "sha512-99drH3mvXakw9we8Rs2cDQmi2pS7PVAC9pvTlB7lHPUwLYftMlko5cFMceZxvTHeyLkdvg98iNIHI3hbnzitoQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "node_modules/axe-core": {
       "version": "4.3.3",
@@ -4622,6 +4660,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -5822,6 +5869,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "node_modules/isbinaryfile": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
@@ -5951,6 +6004,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-beautify": {
@@ -7793,6 +7855,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8202,6 +8274,12 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -9207,6 +9285,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9219,6 +9313,16 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -9411,6 +9515,25 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -11125,6 +11248,42 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
+    },
+    "aws-sdk": {
+      "version": "2.1055.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1055.0.tgz",
+      "integrity": "sha512-99drH3mvXakw9we8Rs2cDQmi2pS7PVAC9pvTlB7lHPUwLYftMlko5cFMceZxvTHeyLkdvg98iNIHI3hbnzitoQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
+        }
+      }
     },
     "axe-core": {
       "version": "4.3.3",
@@ -12938,6 +13097,12 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -13799,6 +13964,12 @@
         "is-docker": "^2.0.0"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isbinaryfile": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
@@ -13898,6 +14069,12 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-beautify": {
       "version": "1.14.0",
@@ -15320,6 +15497,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15618,6 +15801,12 @@
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "section-matter": {
       "version": "1.0.0",
@@ -16419,6 +16608,24 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16429,6 +16636,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -16569,6 +16782,22 @@
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "requires": {}
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "site:watch:dev": "cross-env NODE_ENV=development eleventy --serve --incremental",
     "site:start": "npm run site:watch",
     "site:dev": "npm run site:watch:dev",
-    "build": "echo \"WARN: no build specified\" && exit 0" 
+    "build": "echo \"WARN: no build specified\" && exit 0"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "@web/dev-server": "^0.1.17",
     "@web/test-runner": "^0.13.16",
     "@web/test-runner-puppeteer": "^0.10.1",
+    "aws-sdk": "^2.1055.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "husky": "^7.0.4",


### PR DESCRIPTION
Added a script that publishes the dist folder of a component to the CDN at:
```
components/${packageName}/v${packageVersion}/dist/*
```

This called from the prePublish hook and will cancel the publish process if it fails

If this is acceptable we can use this process for other components until we reorganize into a more centralized operation