### PR TITLE
Fix component pages

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,7 +1,9 @@
 .github
 .husky
-components/**/!(*.md|*.11tydata.*)
 test
+components/index.html
+components/*/*.(json|html|js|css|scss)
+components/*/*/**/*
 package.json
 package-lock.json
 README.md


### PR DESCRIPTION
This PR fixes a severe bug I discovered in component page rendering. It wasn't happening. At all. I believe the culprit was our upgrade to 11ty 1.0. I fixed it by reconfiguring our `.eleventyignore` file. 