### PR TITLE
updated a11y it statewide-header #335

### DIFF
--- a/components/statewide-header/CHANGELOG.md
+++ b/components/statewide-header/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG for ds-statewide-header
 `ds-statewide-header`
 
+
+# 1.0.12
+* Made cagov logo linked to ca.gov website.
+* Added aria-hidden=”true” attribute to the ca.gov svg icon, so it is hidden from assistive technologies.
+
 # 1.0.11
 * Linted and formatted code per root eslint/prettier settings.
 * Added unit test.

--- a/components/statewide-header/package-lock.json
+++ b/components/statewide-header/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-statewide-header",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "license": "ISC",
       "devDependencies": {
         "sass": "^1.37.5"

--- a/components/statewide-header/package.json
+++ b/components/statewide-header/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "",
   "main": "index.css",
   "type": "module",
   "scripts": {
     "test": "web-test-runner \"test/**/*.js\" --node-resolve",
     "test:visual": "web-test-runner \"test/**/*.js\" --node-resolve --config test-config.js",
-      "build": "sass src/index.scss index.css"
+    "build": "sass src/index.scss index.css"
   },
   "keywords": [],
   "author": "",
@@ -16,5 +16,5 @@
     "@open-wc/testing": "^3.0.1",
     "@web/test-runner-puppeteer": "^0.10.2",
     "sass": "^1.37.5"
-    }
+  }
 }

--- a/components/statewide-header/readme.md
+++ b/components/statewide-header/readme.md
@@ -27,7 +27,8 @@ The instructions assume familiarity with [npm](https://npmjs.com) package manage
 <div class="official-header">
   <div class="container">
     <div class="official-logo">
-        <svg title="ca.gov logo" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+      <a class="cagov-logo" href="https://ca.gov" title="ca.gov" target="_blank">
+        <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
             y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"
             xml:space="preserve">
           <path class="ca" d="M27.4,14c0.1-0.4,0.4-1.5,0.9-3.2c0.1-0.5,0.4-1.3,0.9-2.7c0.5-1.4,0.9-2.5,1.2-3.3c-0.9,0.6-1.8,1.4-2.7,2.3
@@ -55,6 +56,7 @@ The instructions assume familiarity with [npm](https://npmjs.com) package manage
             <polygon class="gov" points="36.3,21.6 38,21.6 40.1,27.6 42.2,21.6 43.9,21.6 40.8,30 39.3,30 36.3,21.6 	"/>
           </g>
         </svg>
+        </a>
       <p class="official-tag"><span class="desktop-only">Official website of the</span> State of California</p>
     </div>
     <cagov-google-translate />

--- a/components/statewide-header/template.html
+++ b/components/statewide-header/template.html
@@ -1,9 +1,8 @@
 <div class="official-header">
   <div class="container">
     <div class="official-logo">
-        <svg title="ca.gov logo" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-            y="0px" width="44px" height="34px" viewBox="0 0 44 34" style="enable-background:new 0 0 44 34;"
-            xml:space="preserve">
+      <a class="cagov-logo" href="https://ca.gov" title="ca.gov" target="_blank">
+        <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="44px" height="34px" viewbox="0 0 44 34" style="enable-background:new 0 0 44 34;" xml:space="preserve">
           <path class="ca" d="M27.4,14c0.1-0.4,0.4-1.5,0.9-3.2c0.1-0.5,0.4-1.3,0.9-2.7c0.5-1.4,0.9-2.5,1.2-3.3c-0.9,0.6-1.8,1.4-2.7,2.3
         c-3.2,3.5-6.9,7.6-8.3,9.8c0.5-0.1,1.5-1.2,4.7-2.3C26.3,14,27.4,14,27.4,14L27.4,14z M26.9,16.2c-10.1,0-14.5,16.1-21.6,16.1
         c-1.6,0-2.8-0.7-3.7-2.1c-0.6-0.9-0.8-2-0.8-3.1c0-2.9,1.4-6.7,4.2-11.1c2.4-3.8,4.9-6.9,7.5-9.2c2.3-2,4.2-3,5.9-3
@@ -29,8 +28,11 @@
             <polygon class="gov" points="36.3,21.6 38,21.6 40.1,27.6 42.2,21.6 43.9,21.6 40.8,30 39.3,30 36.3,21.6 	"/>
           </g>
         </svg>
-      <p class="official-tag"><span class="desktop-only">Official website of the</span> State of California</p>
+      </a>
+      <p class="official-tag">
+        <span class="desktop-only">Official website of the</span>
+        State of California</p>
     </div>
-    <cagov-google-translate />
+    <cagov-google-translate/>
   </div>
 </div>


### PR DESCRIPTION
- Updated statewide header's template.html code and make sure that cagov logo is linked to ca.gov website.
- Made sure that link has title attribute describing the link.
- Made sure that svg icon inside of the cagov-logo has aria-hidden=”true” attribute, so it is hidden from assistive technologies.
