### PR TITLE
Fix principles on homepage

### DIFF
--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -93,7 +93,7 @@ title: California Design System
 </div>
 
 {% set principleNumber = range(1, 9) | random %}
-{% set principle = principles[principleNumber] %}
+{% set principle = editable.principles[principleNumber] %}
 
 <div>
   <cagov-highlight-section>


### PR DESCRIPTION
This PR fixes principles content on the homepage.

I missed this when I moved around the data files yesterday.