### PR TITLE
Add anchors to markdown headers

### DIFF
--- a/docs/src/11ty/markdown.js
+++ b/docs/src/11ty/markdown.js
@@ -1,11 +1,12 @@
 const markdownIt = require('markdown-it');
+const markdownItAnchor = require('markdown-it-anchor');
 const hljs = require('highlight.js');
 
 const md = markdownIt({
   html: true,
   breaks: true,
   linkify: true,
-});
+}).use(markdownItAnchor);
 
 /**
  * Encloses syntax-highlighted code blocks in <pre> and <code> tags.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "cross-env": "^7.0.3",
         "glob": "^7.2.0",
         "highlight.js": "^11.3.1",
-        "markdown-it": "^12.3.0"
+        "markdown-it": "^12.3.0",
+        "markdown-it-anchor": "^8.4.1"
       },
       "devDependencies": {
         "@open-wc/eslint-config": "^4.3.0",
@@ -48,7 +49,7 @@
     },
     "components/agency-footer": {
       "name": "@cagov/ds-agency-footer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -68,7 +69,7 @@
     },
     "components/base-css": {
       "name": "@cagov/ds-base-css",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -88,7 +89,7 @@
     },
     "components/button-grid": {
       "name": "@cagov/ds-button-grid",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -111,7 +112,7 @@
     },
     "components/content-navigation": {
       "name": "@cagov/ds-content-navigation",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -195,7 +196,7 @@
     },
     "components/page-alert": {
       "name": "@cagov/ds-page-alert",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.0-next.2",
@@ -237,7 +238,7 @@
     },
     "components/skip-to-content": {
       "name": "@cagov/ds-skip-to-content",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -247,7 +248,7 @@
     },
     "components/statewide-footer": {
       "name": "@cagov/ds-statewide-footer",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -257,7 +258,7 @@
     },
     "components/statewide-header": {
       "name": "@cagov/ds-statewide-header",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",
@@ -1419,6 +1420,28 @@
       "dependencies": {
         "@types/koa": "*"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -5789,6 +5812,15 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -9399,6 +9431,28 @@
         "@types/koa": "*"
       }
     },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "dev": true
@@ -12232,6 +12286,12 @@
           "version": "2.1.0"
         }
       }
+    },
+    "markdown-it-anchor": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "requires": {}
     },
     "marky": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "cross-env": "^7.0.3",
     "glob": "^7.2.0",
     "highlight.js": "^11.3.1",
-    "markdown-it": "^12.3.0"
+    "markdown-it": "^12.3.0",
+    "markdown-it-anchor": "^8.4.1"
   }
 }


### PR DESCRIPTION
This PR adds `id` attributes to every heading tag generated by markdown. This will enable anchor links to mid-page content.