### PR TITLE
Add tables to component pages

### DIFF
--- a/docs/site/_includes/layouts/component-index.njk
+++ b/docs/site/_includes/layouts/component-index.njk
@@ -63,7 +63,7 @@
         <div class="everylayout">
           <main id="body-content" class="main-primary">
             <article id="post-{{ componentSlug }}-{{ page.fileSlug }}">
-              <div class="entry-content">
+              <div class="entry-content cagov-table">
                 {{ content | safe }}
               </div>
             </article>

--- a/docs/src/css/sass/index.scss
+++ b/docs/src/css/sass/index.scss
@@ -17,6 +17,7 @@
 @import '../../../../components/table/src/index.scss';
 @import '../../../../components/page-alert/src/index.scss';
 @import '../../../../components/regulatory-outline/src/index.scss';
+@import '../../../../components/table/dist/index';
 
 /* NAVIGATION ELEMENTS */
 @import '../../../../components/statewide-header/src/index.scss';


### PR DESCRIPTION
Adds tables to component pages. 

Not a huge fan of the way the `.cagov-table` class needs to be used here, but it gets the job done for now.