### PR TITLE
Remove Support from nav menu

### DIFF
--- a/docs/site/_includes/menu.njk
+++ b/docs/site/_includes/menu.njk
@@ -74,11 +74,13 @@
           </div>
         </div>
         
+        {#
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header"><a class="expanded-menu-section-header-link js-event-hm-menu" href="/support/">Support</a></strong>
           </div>
         </div>
+        #}
 
         {% if env.dev %}
           <div class="expanded-menu-col js-cagov-navoverlay-expandable">


### PR DESCRIPTION
This PR removes the Support link from the main navigation menu.