### PR TITLE
Improve page titles

### DIFF
--- a/components/components.11tydata.js
+++ b/components/components.11tydata.js
@@ -6,19 +6,6 @@ const defaults = require('../docs/site/_data/editable/defaults.json');
 const getComponentSlug = (article) =>
   article.page.filePathStem.match(/\/components\/(.+?)\/.+/)[1];
 
-const normalizePagename = (basename) => {
-  if (basename.toLowerCase() === 'readme') {
-    return 'Readme';
-  }
-  if (basename.toLowerCase() === 'changelog') {
-    return 'Changelog';
-  }
-  if (basename.toLowerCase() === 'use-cases') {
-    return 'Use cases';
-  }
-  return basename;
-};
-
 module.exports = {
   layout: 'component-page',
   tags: ['component'],
@@ -49,22 +36,20 @@ module.exports = {
     title: (article) => {
       const componentSlug = getComponentSlug(article);
       const component = components[componentSlug];
-      const filename = article.page.fileSlug;
-      let pagename = '';
+      // const filename = article.page.fileSlug;
 
       if (component) {
-        pagename += `${component.name}: `;
+        return `${component.title} | ${defaults.site.name}`;
       }
 
-      pagename += normalizePagename(filename);
-      return pagename;
+      return defaults.site.name;
     },
     description: (article) => {
       const componentSlug = getComponentSlug(article);
       const component = components[componentSlug];
 
       if (component) {
-        return component.blurb;
+        return component.description;
       }
 
       return defaults.page.description;

--- a/docs/pages/components.md
+++ b/docs/pages/components.md
@@ -1,6 +1,6 @@
 ---
 layout: component-index
-title: Design System Components
+title: Components
 description: Components are the structural elements of the State of California Design System. They meet common user needs and can be reused across websites.
 ---
 

--- a/docs/site/_data/editable/components.json
+++ b/docs/site/_data/editable/components.json
@@ -1,146 +1,182 @@
 {
   "feedback": {
     "name": "Page feedback",
+    "title": "Page feedback",
     "type": "structural",
     "status": "Alpha",
     "blurb": "Widget that lets people provide feedback on page content",
+    "description": "Widget that lets people provide feedback on page content",
     "slug": "feedback",
     "icon": "/img/ds-feedback.png"
   },
   "agency-footer": {
     "name": "Site footer",
+    "title": "Site footer",
     "type": "structural",
     "status": "Alpha",
     "blurb": "Customizable links and social media icons at the bottom of all pages",
+    "description": "Customizable links and social media icons at the bottom of all pages",
     "slug": "agency-footer",
     "icon": "/img/ds-agency-footer.png",
     "new": true
   },
   "branding": {
     "name": "Site header",
+    "title": "Site header",
     "type": "structural",
     "status": "Alpha",
     "blurb": "The site name and logo with an optional search bar at the top of all pages",
+    "description": "The site name and logo with an optional search bar at the top of all pages",
     "slug": "branding",
     "icon": "/img/ds-branding.png"
   },
   "statewide-footer": {
     "name": "Statewide footer",
+    "title": "Statewide footer",
     "type": "structural",
     "status": "Alpha",
     "blurb": "State of California standard footer",
+    "description": "State of California standard footer",
     "slug": "statewide-footer",
     "icon": "/img/ds-statewide-footer.png"
   },
   "statewide-header": {
     "name": "Statewide header",
+    "title": "Statewide header",
     "type": "structural",
     "status": "Alpha",
     "blurb": "State of California standard header",
+    "description": "State of California standard header",
     "slug": "statewide-header",
     "icon": "/img/ds-statewide-header.png"
   },
   "back-to-top": {
     "name": "Back to top button",
+    "title": "Back to top button",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "A button that lets people go back to the top of the page without scrolling",
+    "description": "A button that lets people go back to the top of the page without scrolling",
     "slug": "back-to-top",
     "icon": "/img/ds-back-to-top.png"
   },
   "link-icon": {
     "name": "Link icon",
+    "title": "Link icon",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "Icons that tell people if a link goes to another website or a PDF",
+    "description": "Icons that tell people if a link goes to another website or a PDF",
     "slug": "link-icon",
     "icon": "/img/ds-link-icon.png"
   },
   "content-navigation": {
     "name": "Page navigation",
+    "title": "Page navigation",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "Links on the left side of a page that go directly to major sections of a page",
+    "description": "Links on the left side of a page that go directly to major sections of a page",
     "slug": "content-navigation",
     "icon": "/img/ds-content-navigation.png"
   },
   "pagination": {
     "name": "Pagination",
+    "title": "Pagination",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "Splits ordered lists into numbered pages shown one at a time",
+    "description": "Splits ordered lists into numbered pages shown one at a time",
     "slug": "pagination",
     "icon": "/img/ds-pagination.png"
   },
   "menu": {
     "name": "Site navigation",
+    "title": "Site navigation",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "Links and dropdown menus at the top of every page that let people move around the site",
+    "description": "Links and dropdown menus at the top of every page that let people move around the site",
     "slug": "menu",
     "icon": "/img/ds-menu.png"
   },
   "skip-to-content": {
     "name": "Skip to content",
+    "title": "Skip to content",
     "type": "navigation",
     "status": "Alpha",
     "blurb": "Accessibility feature that lets people skip the header content",
+    "description": "Accessibility feature that lets people skip the header content",
     "slug": "skip-to-content",
     "icon": "/img/ds-skip-to-content.png"
   },
   "base-css": {
     "name": "Base CSS",
+    "title": "Base CSS",
     "type": "visual",
     "status": "Alpha",
     "blurb": "Blurb.",
+    "description": "Blurb.",
     "slug": "base-css",
     "icon": "/img/ds-base-css.png"
   },
   "accordion": {
     "name": "Accordion",
+    "title": "Accordion",
     "type": "content",
     "status": "Alpha",
     "blurb": "An expandable section of content that lets people choose what they want to see",
+    "description": "An expandable section of content that lets people choose what they want to see",
     "slug": "accordion",
     "icon": "/img/ds-accordion.png"
   },
   "feature-card": {
     "name": "Feature card",
+    "title": "Feature card",
     "type": "content",
     "status": "Alpha",
     "blurb": "A highlight space on the homepage with text, image, and a button",
+    "description": "A highlight space on the homepage with text, image, and a button",
     "slug": "feature-card",
     "icon": "/img/ds-feature-card.png"
   },
   "button-grid": {
     "name": "Link grid",
+    "title": "Link grid",
     "type": "content",
     "status": "Alpha",
     "blurb": "Grid of call-to-action buttons for top user tasks and needs",
+    "description": "Grid of call-to-action buttons for top user tasks and needs",
     "slug": "button-grid",
     "icon": "/img/ds-button-grid.png"
   },
   "page-alert": {
     "name": "Page alert",
+    "title": "Page alert",
     "type": "content",
     "status": "Alpha",
     "blurb": "A space for high-priority information that can include an icon and links",
+    "description": "A space for high-priority information that can include an icon and links",
     "slug": "page-alert",
     "icon": "/img/ds-page-alert.png"
   },
   "regulatory-outline": {
     "name": "Regulatory outline",
+    "title": "Regulatory outline",
     "type": "content",
     "status": "Alpha",
     "blurb": "A list that replicates the ordering of government code",
+    "description": "A list that replicates the ordering of government code",
     "slug": "regulatory-outline",
     "icon": "/img/ds-regulatory-outline.png"
   },
   "step-list": {
     "name": "Step list",
+    "title": "Step list",
     "type": "content",
     "status": "Alpha",
     "blurb": "A numbered list that shows the steps in a process",
+    "description": "A numbered list that shows the steps in a process",
     "slug": "step-list",
     "icon": "/img/ds-step-list.png"
   }

--- a/docs/site/_data/editable/defaults.json
+++ b/docs/site/_data/editable/defaults.json
@@ -4,7 +4,6 @@
     "keywords": "California, government, design system"
   },
   "page": {
-    "title": "California Design System",
     "description": "California Design System",
     "social_image_path": "/img/thumbnail.png",
     "social_image_width": 500,

--- a/docs/site/_data/eleventyComputed.js
+++ b/docs/site/_data/eleventyComputed.js
@@ -13,6 +13,12 @@ const buildURL = (path, domain) => {
 module.exports = {
   // Note that several metadata properties do not need to be in EleventyComputed.
   // See ./metadata.js for more.
+  title: (article) => {
+    if ('title' in article && article.title !== '') {
+      return `${article.title} | ${defaults.site.name}`;
+    }
+    return defaults.site.name;
+  },
   metadata: {
     canonical_url: (article) => buildURL(article.permalink, root),
     page_description: (article) =>

--- a/docs/site/_data/title.js
+++ b/docs/site/_data/title.js
@@ -1,3 +1,0 @@
-const defaults = require('./editable/defaults.json');
-
-module.exports = defaults.page.title;


### PR DESCRIPTION
This PR appends the site's name to every page title.

It also provides a means to edit page titles and descriptions for component pages, as discussed with Content Team.