### PR TITLE
changed cagov-section-highlight class to lead to fix typography on e homepage #233

### DIFF
--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -28,7 +28,7 @@ description: The Design System makes it easy for state digital teams to build ac
       <img src="/img/target-sketch.svg" alt="sketch of dart in target" />
     </div>
     <div class="cagov-card-body">
-      <a href="/principles/" class="cagov-section-highlight cagov-section-highlight-link">Principles</a>
+      <a href="/principles/" class="lead cagov-section-highlight-link">Principles</a>
       <p class="">Designing excellent services and products is hard. These best practices guide you in your journey.</p>
     </div>
   </div>
@@ -37,7 +37,7 @@ description: The Design System makes it easy for state digital teams to build ac
       <img src="/img/guides-sketch.svg" alt="sketch of checklist" />
     </div>
     <div class="cagov-card-body">
-      <a href="/style/content/" class="cagov-section-highlight cagov-section-highlight-link">Content and design guides</a>
+      <a href="/style/content/" class="lead cagov-section-highlight-link">Content and design guides</a>
       <p>Design systems are only as good as what goes in them. The content and design guides help you consistently build quality services and products.</p>
     </div>
   </div>
@@ -46,7 +46,7 @@ description: The Design System makes it easy for state digital teams to build ac
       <img src="/img/library-sketch.svg" alt="sketch of control panel" />
     </div>
     <div class="cagov-card-body">
-      <a href="/components/" class="cagov-section-highlight cagov-section-highlight-link">Component library</a>
+      <a href="/components/" class="lead cagov-section-highlight-link">Component library</a>
       <p>You do not have to reinvent the wheel every time you need a digital solution. The components solve common user needs for you.</p>
     </div>
   </div>
@@ -58,7 +58,7 @@ description: The Design System makes it easy for state digital teams to build ac
       <h2>What design systems do</h2>
     </div>
     <div class="cagov-mb-1">
-      <p class="cagov-section-highlight cagov-mb-3">Design systems provide solutions to common problems digital teams face. They combine UX principles, interface components, and code. Teams work faster, design better, and focus on new problems instead of old ones.</p>
+      <p class="lead cagov-mb-3">Design systems provide solutions to common problems digital teams face. They combine UX principles, interface components, and code. Teams work faster, design better, and focus on new problems instead of old ones.</p>
       <div class="cagov-cluster-3">
         <span>
           <p class="cagov-bold">Consistent user experiences</p>

--- a/docs/src/css/sass/grids.scss
+++ b/docs/src/css/sass/grids.scss
@@ -11,21 +11,19 @@
     grid-gap: 1.5rem;
   }
 }
-.cagov-section-highlight {
-  font-size: 23px; /* got these numbers from figma, weird they are not divisible by 4 */
-  line-height: 39px;
-}
+
 .cagov-section-highlight-link {
   text-decoration: none;
   font-weight: 700;
 }
-.cagov-cluster-3, .cagov-cluster-big-2 {
+.cagov-cluster-3,
+.cagov-cluster-big-2 {
   .cagov-stack-card {
-    border-radius: 5px;  
+    border-radius: 5px;
   }
 }
 .cagov-stack-card {
-  background-color: #F9F9FA;
+  background-color: #f9f9fa;
   .cagov-card-head {
     background: #b3c9eb;
     min-height: 176px;
@@ -65,7 +63,7 @@
     .cagov-card-body {
       border-radius: 0 0 5px 5px;
     }
- }
+  }
 }
 
 /* utility class added for this section */

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,7 +217,7 @@
     },
     "components/highlight-section": {
       "name": "@cagov/ds-highlight-section",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",


### PR DESCRIPTION
Instead of using custom "cagov-section-highlight" use common "lead" class specified in base-css typography.scss. These typography styles are specified in figma also:
![Screen Shot 2022-01-20 at 9 28 14 AM](https://user-images.githubusercontent.com/31669748/150390740-fb27f9ca-7e4b-4c3e-b6e8-f237f42f8e14.png)

