### PR TITLE
Agency footer - CONTRIBUTORS and CHANGELOG

### DIFF
--- a/components/agency-footer/CHANGELOG.md
+++ b/components/agency-footer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 `ds-agency-footer`
 
+# 1.0.4
+* Force social media icons onto the same line on Safari. 
+
 # 1.0.3
 * Added visible gray-300 top and bottom borders 
 

--- a/components/agency-footer/CONTRIBUTORS.md
+++ b/components/agency-footer/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+
+## Scripts for contributers
+
+### Develop
+
+- `npm run build`  :  Compile CSS. 
+
+### Verify
+
+- `npm run html:preview`  :  Update preview in design system website readme.
+
+- `npm test` : Run automated accessibility test.
+
+- `npm run test:visual` : Run automated accessibility test in a browser.
+
+
+###  Publish 
+
+[See instructions at ODI wiki](https://github.com/cagov/odi-engineering/wiki/How-to-publish-a-package-to-npm) to publish to npm. You will need credentials to publish to npm and AWS. On npm publish the following scripts will run:
+
+- `npm run html:preview`  :  Update preview in design system website readme.
+
+- `npm run build`  :  Compile CSS.
+
+- `npm run test` : Run automated accessibility test.
+
+- `npm run cdn:publish` : Publish to AWS CDN.

--- a/components/agency-footer/CONTRIBUTORS.md
+++ b/components/agency-footer/CONTRIBUTORS.md
@@ -1,5 +1,5 @@
 
-## Scripts for contributers
+## Scripts for contributors
 
 ### Develop
 

--- a/components/agency-footer/package.json
+++ b/components/agency-footer/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.4",
   "description": "",
   "main": "index.css",
+  "type": "module",
   "scripts": {
     "build": "sass src/index.scss index.css",
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",

--- a/components/agency-footer/package.json
+++ b/components/agency-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-agency-footer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.css",
   "scripts": {


### PR DESCRIPTION
- Added contributors.md 
- I think we should remove test:visual since it's not as useful as preview is now.