### PR TITLE
Remove "new" label from site footer

### DIFF
--- a/docs/site/_data/editable/components.json
+++ b/docs/site/_data/editable/components.json
@@ -11,7 +11,6 @@
     "svg": "svg/page-feedback.svg"
   },
   "agency-footer": {
-    "new": true,
     "name": "Site footer",
     "title": "Site footer",
     "type": "structural",


### PR DESCRIPTION
Removes the "new" label from the site footer in the component sidebar menu.

Closes #478.