### PR TITLE
Restore component SVGs in Safari

### DIFF
--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -36,6 +36,10 @@
     align-items: center;
     justify-content: center;
     padding: 2rem;
+    svg {
+      height: 100%;
+      width: 100%;
+    }
   }
   &-content {
     padding: 1rem;


### PR DESCRIPTION
Fixes disappearance of component SVG illustrations on the components page.

Closes #440, #447.