### PR TITLE
Remove H1s from special markdown processing

### DIFF
--- a/docs/src/11ty/markdown.js
+++ b/docs/src/11ty/markdown.js
@@ -6,7 +6,7 @@ const md = markdownIt({
   html: true,
   breaks: true,
   linkify: true,
-}).use(markdownItAnchor);
+}).use(markdownItAnchor, { level: 2 });
 
 /**
  * Encloses syntax-highlighted code blocks in <pre> and <code> tags.


### PR DESCRIPTION
Fixes the bizarre vertical header on the skip-to-content page by removing H1 headings from special markdown processing (which adds `id` to every heading for the purposes of mid-page anchor-linking).

Closes #432.