### PR TITLE
Remove form action from site-header search example

### DIFF
--- a/components/branding/readme.md
+++ b/components/branding/readme.md
@@ -132,7 +132,7 @@ Do not modify the site header beyond adding the site name and a logo.
     </div>
 
     <div class="search-container grid-search">
-      <form class="site-search" action="/serp/">
+      <form class="site-search">
         <span class="sr-only" id="SearchInput">Custom Google Search</span>
         <input
           type="text"
@@ -235,7 +235,7 @@ Do not modify the site header beyond adding the site name and a logo.
     </div>
 
     <div class="search-container grid-search">
-      <form class="site-search" action="/serp/">
+      <form class="site-search">
         <span class="sr-only" id="SearchInput">Custom Google Search</span>
         <input
           type="text"

--- a/components/branding/template.html
+++ b/components/branding/template.html
@@ -102,7 +102,7 @@
     </div>
 
     <div class="search-container grid-search">
-      <form class="site-search" action="/serp/">
+      <form class="site-search">
         <span class="sr-only" id="SearchInput">Custom Google Search</span>
         <input
           type="text"

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -190,6 +190,7 @@
   border: solid 1px #A09FA7;
   background-color: #f9f9fa;
   padding: 1rem;
+  margin: 1rem 0;
   &-demo {
     border: solid 1px #A09FA7;
     background-color: white;


### PR DESCRIPTION
Fixes a problem where entering a query into the search box on the site-header demo would go to a 404 page.

I think we could do a lot more to improve this demo. And I think this demo, in particular, calls into question the wisdom behind automatically merging our test `template.html` mark-up into the `readme.md`. The needs of our test code diverge significantly from the needs of simple communication re: how to use a component. 

But this fix stops the bleeding, at least.

Closes #485.