### PR TITLE
update changelog, explain higher version numbers

### DIFF
--- a/components/accordion/CHANGELOG.md
+++ b/components/accordion/CHANGELOG.md
@@ -1,36 +1,34 @@
-# Content components >> Accordion >> Changelog || 20
+# Accordion Changelog
 
-`ds-accordion`
+<a href="https://www.npmjs.com/package/@cagov/ds-accordion">https://www.npmjs.com/package/@cagov/ds-accordion</a>
 
-# 1.0.10
-* Remove unnecessary constructor, auto synch sample markup docs with markup used in test
-
-# 1.0.9
+## 1.0.9
 * Add prepublish hook which writes latest sample HTML into readme from template.html
 * Update description to match latest design system docs
-# 1.0.8
+
+## 1.0.8
 * Linted and formatted code per root eslint/prettier settings.
 * Added unit test.
 
-# 2.0.7 (ds-accordion)
+## 1.0.7
 * Added src folder with index.scss file to be consistent with the rest of the ds components.
 
-# 2.0.11
+## Previous versions
+
+This package was previously published under the name @cagov/accordion which has now been deprecated. Higher version numbers below refer to the retired package name.
+
+## 2.0.11
 * Fixed "allbuttons is not defined" console error.
 
 # 2.0.10
 * Fixed tabindex for the links that are inside of the accordions that are open by default.
 
-# 2.0.9
+## 2.0.9
 * Included base css styles inside the accordion component itself so it can run well without any of the global site styles, put initial on page load tabindex generation inside of the callback class.
 * Clean out old code.
 
-# 2.0.8
+## 2.0.8
 * All links and buttons inside of the collapsed accordion container now have attibute tabindex -1, this attribute is removed as soone as accordion container is expanded.
 
-# 2.0.7
+## 2.0.7
 * Make hidden links really hidden to Screen Reader, by changing the body container to be "display: none".
-
-
-# 2.0.6 
-@TODO find old notes

--- a/components/accordion/CHANGELOG.md
+++ b/components/accordion/CHANGELOG.md
@@ -20,7 +20,7 @@ This package was previously published under the name @cagov/accordion which has 
 ## 2.0.11
 * Fixed "allbuttons is not defined" console error.
 
-# 2.0.10
+## 2.0.10
 * Fixed tabindex for the links that are inside of the accordions that are open by default.
 
 ## 2.0.9


### PR DESCRIPTION
- Added explanation to this changelog which had older, higher version numbers because it referred to a different package name.
- Took the legacy rocket syntax out of the changelog page title
- Changed the package name reference to be a link to npm

The last two items can be done everywhere if we like these updates