### PR TITLE
493 regulatory outline

### DIFF
--- a/components/regulatory-outline/CHANGELOG.md
+++ b/components/regulatory-outline/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Regulatory outline changelog 
+
+`ds-regulatory-outline`
+
+# 1.0.3
+* Decrease padding and use utility variables. 

--- a/components/regulatory-outline/CONTRIBUTORS.md
+++ b/components/regulatory-outline/CONTRIBUTORS.md
@@ -1,0 +1,24 @@
+
+## Scripts for contributors
+
+### Develop
+
+- `npm run build`  :  Compile CSS. 
+
+### Verify
+
+- `npm run html:preview`  :  Update preview in design system website readme.
+
+- `npm test` : Run automated accessibility test.
+
+###  Publish 
+
+[See instructions at ODI wiki](https://github.com/cagov/odi-engineering/wiki/How-to-publish-a-package-to-npm) to publish to npm. You will need credentials to publish to npm and AWS. On npm publish the following scripts will run:
+
+- `npm run html:preview`  :  Update preview in design system website readme.
+
+- `npm run build`  :  Compile CSS.
+
+- `npm run test` : Run automated accessibility test.
+
+- `npm run cdn:publish` : Publish to AWS CDN.

--- a/components/regulatory-outline/dist/index.css
+++ b/components/regulatory-outline/dist/index.css
@@ -1,23 +1,24 @@
 ol.cagov-regulatory-outline, ol.cagov-regulatory-outline ol {
   counter-reset: section;
   list-style-type: none;
-  margin-left: 32px;
-  padding-left: 32px;
+  margin-left: var(--s-2, 24px);
+  padding-left: var(--s-2, 24px);
 }
 ol.cagov-regulatory-outline li, ol.cagov-regulatory-outline ol li {
   counter-increment: section;
   list-style-type: none;
-  margin: 16px 0;
+  margin: calc(var(--s-2, 24px) * 0.5) 0;
+  padding: 0;
   position: relative;
 }
 ol.cagov-regulatory-outline li::before, ol.cagov-regulatory-outline ol li::before {
   content: "(" counter(section, lower-alpha) ") ";
-  width: 100px;
-  margin-left: -32px;
-  padding-right: 32px;
+  width: calc(var(--s-2, 24px) * 3);
+  margin-left: calc(var(--s-2, 24px) * -1);
+  padding-right: calc(var(--s-2, 24px) * 0.5);
   display: inline-block;
   position: absolute;
-  left: -50px;
+  left: calc(var(--s-2, 24px) * -2);
   white-space: nowrap;
   text-align: right;
 }

--- a/components/regulatory-outline/dist/index.css
+++ b/components/regulatory-outline/dist/index.css
@@ -12,6 +12,7 @@ ol.cagov-regulatory-outline li, ol.cagov-regulatory-outline ol li {
   position: relative;
 }
 ol.cagov-regulatory-outline li::before, ol.cagov-regulatory-outline ol li::before {
+  background-color: transparent;
   content: "(" counter(section, lower-alpha) ") ";
   width: calc(var(--s-2, 24px) * 3);
   margin-left: calc(var(--s-2, 24px) * -1);

--- a/components/regulatory-outline/dist/index.css.map
+++ b/components/regulatory-outline/dist/index.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../src/index.scss"],"names":[],"mappings":"AACE;EAEE;EACA;EACA;EACA;;AAEA;EACE;EACA;EACA;EACA;;AAEA;EACE;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;;AAKF;EACE;;AAIA;EACE;;AAGF;EACE","file":"index.css"}
+{"version":3,"sourceRoot":"","sources":["../src/index.scss"],"names":[],"mappings":"AAGE;EAEE;EACA;EACA,aAP8B;EAQ9B,cAR8B;;AAU9B;EACE;EACA;EACA;EACA;EACA;;AAEA;EACE;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;;AAKF;EACE;;AAIA;EACE;;AAGF;EACE","file":"index.css"}

--- a/components/regulatory-outline/package.json
+++ b/components/regulatory-outline/package.json
@@ -9,8 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
-    "test": "web-test-runner test/test.index.js --node-resolve",
-    "test:visual": "web-test-runner test/test.index.js --node-resolve --config test/test.config.js"
+    "test": "web-test-runner test/test.index.js --node-resolve"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.0.3",

--- a/components/regulatory-outline/package.json
+++ b/components/regulatory-outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-regulatory-outline",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Nested, ordered list with the following pattern: (a)(b)(c), (1)(2)(3), (A)(B)(C), (i)(ii)(iii)",
   "main": "src/index.html",
   "type": "module",

--- a/components/regulatory-outline/readme.md
+++ b/components/regulatory-outline/readme.md
@@ -29,38 +29,16 @@ Do not use the regulatory outline for content that is not regulations or governm
 ```html preview
 <ol class="cagov-regulatory-outline">
   <li>
-    LEVEL ONE A law enforcement agency may only use a person under 21 years of
+    A law enforcement agency may only use a person under 21 years of
     age to attempt to purchase alcoholic beverages for delivery to apprehend
-    licensees, or employees or agents of licensees, who deliver alcoholic
-    beverages to minors (persons under 21 years of age), and to reduce
-    deliveries of alcoholic beverages to minors, in a fashion that promotes
-    fairness. For purposes of this section, fairness is defined as compliance
-    with all the conditions set forth in subdivision (e).
+    licensees, ...
   </li>
   <li>
     For purposes of this section, “delivery” shall mean any transfer of
     alcoholic beverages by a licensee, or an employee or agent of a licensee, to
-    a person under 21 years of age, pursuant to an order made by internet,
-    telephone, other electronic means, or any method of ordering other than in
-    person at the licensed premises.
+    a person under 21 years of age, ...
   </li>
-  <li>
-    For purposes of this section, “agent” shall mean any entity or person the
-    licensee uses to deliver alcoholic beverages to persons who place orders by
-    internet, telephone, other electronic means, or any method of ordering other
-    than in person at the licensed premises, whether by contract or agreement,
-    even if not an employee of the licensee, including but not limited to a
-    third-party delivery person or service.
-  </li>
-  <li>
-    For purposes of this section, “minor decoy” shall mean a person used by law
-    enforcement pursuant to Business and Professions Code section 25658(f).
-  </li>
-  <li>
-    The following minimum standards shall apply to actions filed pursuant to
-    Business and Professions Code Section 25658 in which it is alleged a minor
-    decoy has been furnished an alcoholic beverage by delivery:
-  </li>
+  
   <li>
     The following minimum standards shall apply to actions filed pursuant to
     Business and Professions Code Section 25658 in which it is alleged a minor
@@ -68,33 +46,9 @@ Do not use the regulatory outline for content that is not regulations or governm
 
     <ol>
       <li>
-        LEVEL TWO A law enforcement agency may only use a person under 21 years
+        A law enforcement agency may only use a person under 21 years
         of age to attempt to purchase alcoholic beverages for delivery to
-        apprehend licensees, or employees or agents of licensees, who deliver
-        alcoholic beverages to minors (persons under 21 years of age), and to
-        reduce deliveries of alcoholic beverages to minors, in a fashion that
-        promotes fairness. For purposes of this section, fairness is defined as
-        compliance with all the conditions set forth in subdivision (e).
-      </li>
-      <li>
-        For purposes of this section, “delivery” shall mean any transfer of
-        alcoholic beverages by a licensee, or an employee or agent of a
-        licensee, to a person under 21 years of age, pursuant to an order made
-        by internet, telephone, other electronic means, or any method of
-        ordering other than in person at the licensed premises.
-      </li>
-      <li>
-        For purposes of this section, “agent” shall mean any entity or person
-        the licensee uses to deliver alcoholic beverages to persons who place
-        orders by internet, telephone, other electronic means, or any method of
-        ordering other than in person at the licensed premises, whether by
-        contract or agreement, even if not an employee of the licensee,
-        including but not limited to a third-party delivery person or service.
-      </li>
-      <li>
-        For purposes of this section, “minor decoy” shall mean a person used by
-        law enforcement pursuant to Business and Professions Code section
-        25658(f).
+        apprehend licensees...
       </li>
       <li>
         The following minimum standards shall apply to actions filed pursuant to
@@ -113,58 +67,20 @@ Do not use the regulatory outline for content that is not regulations or governm
             in subdivision (e).
           </li>
           <li>
-            For purposes of this section, “delivery” shall mean any transfer of
-            alcoholic beverages by a licensee, or an employee or agent of a
-            licensee, to a person under 21 years of age, pursuant to an order
-            made by internet, telephone, other electronic means, or any method
-            of ordering other than in person at the licensed premises.
-          </li>
-          <li>
-            For purposes of this section, “agent” shall mean any entity or
-            person the licensee uses to deliver alcoholic beverages to persons
-            who place orders by internet, telephone, other electronic means, or
-            any method of ordering other than in person at the licensed
-            premises, whether by contract or agreement, even if not an employee
-            of the licensee, including but not limited to a third-party delivery
-            person or service.
-          </li>
-          <li>
-            For purposes of this section, “minor decoy” shall mean a person used
-            by law enforcement pursuant to Business and Professions Code section
-            25658(f).
-          </li>
-          <li>
             The following minimum standards shall apply to actions filed
             pursuant to Business and Professions Code Section 25658 in which it
             is alleged a minor decoy has been furnished an alcoholic beverage by
             delivery:
             <ol>
               <li>
-                LEVEL FOUR A law enforcement agency may only use a person under
-                21 years of age to attempt to purchase alcoholic beverages for
-                delivery to apprehend licensees, or employees or agents of
-                licensees, who deliver alcoholic beverages to minors (persons
-                under 21 years of age), and to reduce deliveries of alcoholic
-                beverages to minors, in a fashion that promotes fairness. For
-                purposes of this section, fairness is defined as compliance with
-                all the conditions set forth in subdivision (e).
+                A law enforcement agency may only use a person under
+                21 years of age to attempt ...
               </li>
               <li>
-                For purposes of this section, “delivery” shall mean any transfer
-                of alcoholic beverages by a licensee, or an employee or agent of
-                a licensee, to a person under 21 years of age, pursuant to an
-                order made by internet, telephone, other electronic means, or
-                any method of ordering other than in person at the licensed
-                premises.
+                For purposes of this section, ...
               </li>
               <li>
-                For purposes of this section, “agent” shall mean any entity or
-                person the licensee uses to deliver alcoholic beverages to
-                persons who place orders by internet, telephone, other
-                electronic means, or any method of ordering other than in person
-                at the licensed premises, whether by contract or agreement, even
-                if not an employee of the licensee, including but not limited to
-                a third-party delivery person or service.
+                For purposes of this section, “agent” ...
               </li>
               <li>
                 For purposes of this section, “minor decoy” shall mean a person
@@ -173,14 +89,7 @@ Do not use the regulatory outline for content that is not regulations or governm
               </li>
 
               <li>
-                A law enforcement agency may only use a person under 21 years of
-                age to attempt to purchase alcoholic beverages for delivery to
-                apprehend licensees, or employees or agents of licensees, who
-                deliver alcoholic beverages to minors (persons under 21 years of
-                age), and to reduce deliveries of alcoholic beverages to minors,
-                in a fashion that promotes fairness. For purposes of this
-                section, fairness is defined as compliance with all the
-                conditions set forth in subdivision (e).
+                A law enforcement agency may only ...
               </li>
               <li>
                 For purposes of this section, “delivery” shall mean any transfer
@@ -193,11 +102,7 @@ Do not use the regulatory outline for content that is not regulations or governm
               <li>
                 For purposes of this section, “agent” shall mean any entity or
                 person the licensee uses to deliver alcoholic beverages to
-                persons who place orders by internet, telephone, other
-                electronic means, or any method of ordering other than in person
-                at the licensed premises, whether by contract or agreement, even
-                if not an employee of the licensee, including but not limited to
-                a third-party delivery person or service.
+                persons who place orders by internet ...
               </li>
               <li>
                 For purposes of this section, “minor decoy” shall mean a person
@@ -208,7 +113,7 @@ Do not use the regulatory outline for content that is not regulations or governm
                 The following minimum standards shall apply to actions filed
                 pursuant to Business and Professions Code Section 25658 in which
                 it is alleged a minor decoy has been furnished an alcoholic
-                beverage by delivery:
+                beverage by delivery.
               </li>
             </ol>
           </li>

--- a/components/regulatory-outline/readme.md
+++ b/components/regulatory-outline/readme.md
@@ -16,7 +16,7 @@ If possible, rewrite information from regulations or government code using plain
 
 If you must put regulations or government code on your webpage, use the regulatory outline. It allows you to publish properly formatted regulations without using PDFs, which may not meet accessibility standards.
 
-To use the regulatory outline, apply the `cagov-regulatory-outline` class to the list. You can also go into code editor view and apply `.cagov-regulatory-outline <ol>` to the tag. All child `<li>` and `<ol>` tags will inherit the appropriate list styles up to 4 levels deep.
+To use the regulatory outline, apply the `cagov-regulatory-outline` class to the `<ol>` tag. All child `<li>` and `<ol>` tags will inherit the appropriate list styles up to 4 levels deep.
 
 ### How not to use it
 
@@ -235,7 +235,7 @@ The instructions assume familiarity with [npm](https://npmjs.com) package manage
 
 1. Include **SCSS** in your compiler.
 2. Add the **sample markup** from the component to your HTML.
-3. You may need to adjust `margin-left` depending on your default font size.
+3. You may need to adjust `$cagov-regulatory-outline-margin` depending on your default font size.
 
 ## Progressive enhancement
 
@@ -244,11 +244,3 @@ This is an HTML- and CSS-only component. JavaScript is not required. It uses [CS
 ## Content model
 
 This component requires `ol.cagov-regulatory-outline`. It will not work with `ul`.
-
-## Contributor/Developer documenation
-
-`npm run build` - Generate css from scss files.
-
-`npm run test` - Run headless tests with [Open Web Components](https://open-wc.org/).
-
-`npm run test:visual` - Run headed tests with [Open Web Components](https://open-wc.org/).

--- a/components/regulatory-outline/src/index.scss
+++ b/components/regulatory-outline/src/index.scss
@@ -16,6 +16,7 @@ ol.cagov-regulatory-outline {
       position: relative;
 
       &::before {
+        background-color: transparent;
         content: '(' counter(section, lower-alpha) ') ';
         width: calc($cagov-regulatory-outline-margin * 3);
         margin-left: calc($cagov-regulatory-outline-margin * -1);

--- a/components/regulatory-outline/src/index.scss
+++ b/components/regulatory-outline/src/index.scss
@@ -1,25 +1,28 @@
+$cagov-regulatory-outline-margin: var(--s-2, 24px);
+
 ol.cagov-regulatory-outline {
   &,
   & ol {
     counter-reset: section;
     list-style-type: none;
-    margin-left: 32px;
-    padding-left: 32px;
+    margin-left: $cagov-regulatory-outline-margin;
+    padding-left: $cagov-regulatory-outline-margin;
 
     li {
       counter-increment: section;
       list-style-type: none;
-      margin: 16px 0;
+      margin: calc($cagov-regulatory-outline-margin * 0.5) 0;
+      padding: 0;
       position: relative;
 
       &::before {
-        content: "(" counter(section, lower-alpha) ") ";
-        width: 100px;
-        margin-left: -32px;
-        padding-right: 32px;
+        content: '(' counter(section, lower-alpha) ') ';
+        width: calc($cagov-regulatory-outline-margin * 3);
+        margin-left: calc($cagov-regulatory-outline-margin * -1);
+        padding-right: calc($cagov-regulatory-outline-margin * 0.5);
         display: inline-block;
         position: absolute;
-        left: -50px;
+        left: calc($cagov-regulatory-outline-margin * -2);
         white-space: nowrap;
         text-align: right;
       }
@@ -27,16 +30,16 @@ ol.cagov-regulatory-outline {
 
     ol li {
       &:before {
-        content: "(" counter(section, decimal) ") ";
+        content: '(' counter(section, decimal) ') ';
       }
 
       ol li {
         &:before {
-          content: "(" counter(section, upper-alpha) ") ";
+          content: '(' counter(section, upper-alpha) ') ';
         }
 
         ol li:before {
-          content: "(" counter(section, lower-roman) ") ";
+          content: '(' counter(section, lower-roman) ') ';
         }
       }
     }

--- a/components/regulatory-outline/template.html
+++ b/components/regulatory-outline/template.html
@@ -1,37 +1,15 @@
 <ol class="cagov-regulatory-outline">
   <li>
-    LEVEL ONE A law enforcement agency may only use a person under 21 years of
+    A law enforcement agency may only use a person under 21 years of
     age to attempt to purchase alcoholic beverages for delivery to apprehend
-    licensees, or employees or agents of licensees, who deliver alcoholic
-    beverages to minors (persons under 21 years of age), and to reduce
-    deliveries of alcoholic beverages to minors, in a fashion that promotes
-    fairness. For purposes of this section, fairness is defined as compliance
-    with all the conditions set forth in subdivision (e).
+    licensees, ...
   </li>
   <li>
     For purposes of this section, “delivery” shall mean any transfer of
     alcoholic beverages by a licensee, or an employee or agent of a licensee, to
-    a person under 21 years of age, pursuant to an order made by internet,
-    telephone, other electronic means, or any method of ordering other than in
-    person at the licensed premises.
+    a person under 21 years of age, ...
   </li>
-  <li>
-    For purposes of this section, “agent” shall mean any entity or person the
-    licensee uses to deliver alcoholic beverages to persons who place orders by
-    internet, telephone, other electronic means, or any method of ordering other
-    than in person at the licensed premises, whether by contract or agreement,
-    even if not an employee of the licensee, including but not limited to a
-    third-party delivery person or service.
-  </li>
-  <li>
-    For purposes of this section, “minor decoy” shall mean a person used by law
-    enforcement pursuant to Business and Professions Code section 25658(f).
-  </li>
-  <li>
-    The following minimum standards shall apply to actions filed pursuant to
-    Business and Professions Code Section 25658 in which it is alleged a minor
-    decoy has been furnished an alcoholic beverage by delivery:
-  </li>
+  
   <li>
     The following minimum standards shall apply to actions filed pursuant to
     Business and Professions Code Section 25658 in which it is alleged a minor
@@ -39,33 +17,9 @@
 
     <ol>
       <li>
-        LEVEL TWO A law enforcement agency may only use a person under 21 years
+        A law enforcement agency may only use a person under 21 years
         of age to attempt to purchase alcoholic beverages for delivery to
-        apprehend licensees, or employees or agents of licensees, who deliver
-        alcoholic beverages to minors (persons under 21 years of age), and to
-        reduce deliveries of alcoholic beverages to minors, in a fashion that
-        promotes fairness. For purposes of this section, fairness is defined as
-        compliance with all the conditions set forth in subdivision (e).
-      </li>
-      <li>
-        For purposes of this section, “delivery” shall mean any transfer of
-        alcoholic beverages by a licensee, or an employee or agent of a
-        licensee, to a person under 21 years of age, pursuant to an order made
-        by internet, telephone, other electronic means, or any method of
-        ordering other than in person at the licensed premises.
-      </li>
-      <li>
-        For purposes of this section, “agent” shall mean any entity or person
-        the licensee uses to deliver alcoholic beverages to persons who place
-        orders by internet, telephone, other electronic means, or any method of
-        ordering other than in person at the licensed premises, whether by
-        contract or agreement, even if not an employee of the licensee,
-        including but not limited to a third-party delivery person or service.
-      </li>
-      <li>
-        For purposes of this section, “minor decoy” shall mean a person used by
-        law enforcement pursuant to Business and Professions Code section
-        25658(f).
+        apprehend licensees...
       </li>
       <li>
         The following minimum standards shall apply to actions filed pursuant to
@@ -84,58 +38,20 @@
             in subdivision (e).
           </li>
           <li>
-            For purposes of this section, “delivery” shall mean any transfer of
-            alcoholic beverages by a licensee, or an employee or agent of a
-            licensee, to a person under 21 years of age, pursuant to an order
-            made by internet, telephone, other electronic means, or any method
-            of ordering other than in person at the licensed premises.
-          </li>
-          <li>
-            For purposes of this section, “agent” shall mean any entity or
-            person the licensee uses to deliver alcoholic beverages to persons
-            who place orders by internet, telephone, other electronic means, or
-            any method of ordering other than in person at the licensed
-            premises, whether by contract or agreement, even if not an employee
-            of the licensee, including but not limited to a third-party delivery
-            person or service.
-          </li>
-          <li>
-            For purposes of this section, “minor decoy” shall mean a person used
-            by law enforcement pursuant to Business and Professions Code section
-            25658(f).
-          </li>
-          <li>
             The following minimum standards shall apply to actions filed
             pursuant to Business and Professions Code Section 25658 in which it
             is alleged a minor decoy has been furnished an alcoholic beverage by
             delivery:
             <ol>
               <li>
-                LEVEL FOUR A law enforcement agency may only use a person under
-                21 years of age to attempt to purchase alcoholic beverages for
-                delivery to apprehend licensees, or employees or agents of
-                licensees, who deliver alcoholic beverages to minors (persons
-                under 21 years of age), and to reduce deliveries of alcoholic
-                beverages to minors, in a fashion that promotes fairness. For
-                purposes of this section, fairness is defined as compliance with
-                all the conditions set forth in subdivision (e).
+                A law enforcement agency may only use a person under
+                21 years of age to attempt ...
               </li>
               <li>
-                For purposes of this section, “delivery” shall mean any transfer
-                of alcoholic beverages by a licensee, or an employee or agent of
-                a licensee, to a person under 21 years of age, pursuant to an
-                order made by internet, telephone, other electronic means, or
-                any method of ordering other than in person at the licensed
-                premises.
+                For purposes of this section, ...
               </li>
               <li>
-                For purposes of this section, “agent” shall mean any entity or
-                person the licensee uses to deliver alcoholic beverages to
-                persons who place orders by internet, telephone, other
-                electronic means, or any method of ordering other than in person
-                at the licensed premises, whether by contract or agreement, even
-                if not an employee of the licensee, including but not limited to
-                a third-party delivery person or service.
+                For purposes of this section, “agent” ...
               </li>
               <li>
                 For purposes of this section, “minor decoy” shall mean a person
@@ -144,14 +60,7 @@
               </li>
 
               <li>
-                A law enforcement agency may only use a person under 21 years of
-                age to attempt to purchase alcoholic beverages for delivery to
-                apprehend licensees, or employees or agents of licensees, who
-                deliver alcoholic beverages to minors (persons under 21 years of
-                age), and to reduce deliveries of alcoholic beverages to minors,
-                in a fashion that promotes fairness. For purposes of this
-                section, fairness is defined as compliance with all the
-                conditions set forth in subdivision (e).
+                A law enforcement agency may only ...
               </li>
               <li>
                 For purposes of this section, “delivery” shall mean any transfer
@@ -164,11 +73,7 @@
               <li>
                 For purposes of this section, “agent” shall mean any entity or
                 person the licensee uses to deliver alcoholic beverages to
-                persons who place orders by internet, telephone, other
-                electronic means, or any method of ordering other than in person
-                at the licensed premises, whether by contract or agreement, even
-                if not an employee of the licensee, including but not limited to
-                a third-party delivery person or service.
+                persons who place orders by internet ...
               </li>
               <li>
                 For purposes of this section, “minor decoy” shall mean a person
@@ -179,7 +84,7 @@
                 The following minimum standards shall apply to actions filed
                 pursuant to Business and Professions Code Section 25658 in which
                 it is alleged a minor decoy has been furnished an alcoholic
-                beverage by delivery:
+                beverage by delivery.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
PR for #493:

- Keep psuedo elements from covering borders
- Decrease padding and margins so there's more readability on small screens
- Added Changelog and Contribitor files
- Removed test:visual script
- Shortened example text (some may prefer to have it even shorter but it's useful for development to show how it behaves when numbers get especially long. 
- Changed the readme text a bit because it was inaccurate/confusing. (cc @m-sullivan7 See [preview](493-regulatory-outline.pr.designsystem.webstandards.ca.gov.))


Note of interest: I was going to test this in drought and cannabis but it seems this component is not in use anywhere. I think the original ask was from cannabis? cc: @chachasikes 