### PR TITLE
Add 404 page

### DIFF
--- a/docs/site/error.njk
+++ b/docs/site/error.njk
@@ -1,0 +1,9 @@
+---
+layout: single-column
+permalink: /error.html
+title: Page not found
+---
+
+<h1>We can't find the page you're looking for.</h1>
+
+<p>Try going to our <a href="/">homepage</a>.


### PR DESCRIPTION
Adds a 404 Not Found page, per #479.

Note that this requires an additional set-up step in our S3 bucket's "Static website hosting" properties. The error page needs to be set to "error.html". Already done for production.

Also note that this won't work for our special PR site set-up. If we want to use the error page within a given branch, we'd need to put some additional work to handle 404s into our Lambda@Edge Cloundfront stuff. Seems very low priority.