### PR TITLE
Remove feedback from error page

### DIFF
--- a/docs/site/_includes/agency-footer.njk
+++ b/docs/site/_includes/agency-footer.njk
@@ -7,7 +7,9 @@ ga('send', 'pageview');
 </script>
 <script async defer src='https://www.google-analytics.com/analytics.js'></script>
 
-<cagov-feedback class="cagov-mb-2 d-block" data-endpoint-url="https://fa-go-feedback-001.azurewebsites.net/sendfeedback"></cagov-feedback>
+{% if page.url !== "/error.html" %}
+  <cagov-feedback class="cagov-mb-2 d-block" data-endpoint-url="https://fa-go-feedback-001.azurewebsites.net/sendfeedback"></cagov-feedback>
+{% endif %}
 
 <section aria-label="agency footer" class="agency-footer">
   <div class="container">


### PR DESCRIPTION
A PR to avoid the following situation.

<img width="1258" alt="Screen Shot 2022-01-27 at 12 49 14" src="https://user-images.githubusercontent.com/1208960/151451717-c47c1e69-4535-47e4-af32-959cf4fcf3d2.png">

We have a discussion about this in #479. Some sort of feedback might be valuable here, but the particular contrast in wording between the error page and the feedback widget seems off here.