### PR TITLE
Remove content navigation from contact us page

### DIFF
--- a/docs/pages/contact-us.md
+++ b/docs/pages/contact-us.md
@@ -1,4 +1,5 @@
 ---
+layout: single-column
 title: Contact us
 description: Get help from the State of California Design System team, post questions, and share technical information with fellow developers.
 ---


### PR DESCRIPTION
Removes content navigation from the Contact Us page.

Closes #510.