### PR TITLE
Apply rounded borders to stack card

### DIFF
--- a/docs/src/css/sass/feature-card-variations.scss
+++ b/docs/src/css/sass/feature-card-variations.scss
@@ -129,6 +129,11 @@
   }
 }
 
+.cagov-stack-card {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
 @media (max-width: 800px) {
   .get-involved {
     flex-wrap: wrap-reverse;


### PR DESCRIPTION
Applies rounded borders to cards in the "What's in the Design System" section on the homepage.

Closes #503.