### PR TITLE
574 contact form update

### DIFF
--- a/components/content-navigation/src/index.js
+++ b/components/content-navigation/src/index.js
@@ -358,9 +358,8 @@ class CAGovContentNavigation extends window.HTMLElement {
     let output = '';
     if (headers !== undefined && headers !== null && headers.length > 0) {
       headers.forEach((tag) => {
-
-        let tagId = tag.getAttribute('id');
-        let tagName = tag.getAttribute('name');
+        const tagId = tag.getAttribute('id');
+        const tagName = tag.getAttribute('name');
 
         const title = tag.innerHTML;
 
@@ -400,10 +399,9 @@ class CAGovContentNavigation extends window.HTMLElement {
         output += `<li><a data-content-navigation href="#${encodeURI(
           anchor,
         )}">${title}</a></li>`;
-        
+
         tag.setAttribute('id', anchor);
         tag.setAttribute('name', anchor);
-
       });
       return `<ul>${output}</ul>`;
     }

--- a/docs/pages/contact-us.md
+++ b/docs/pages/contact-us.md
@@ -5,7 +5,7 @@ description: Get help from the State of California Design System team, post ques
 
 # Contact us
 
-Have a question? Email us for help with general inquiries, feedback, or bugs.
+Have a question? Contact us for help with general inquiries, feedback, or bugs.
 
 {%- from "macros/contact-us-form-wrapper.njk" import wrappedContactForm -%}
 {{ wrappedContactForm("Contact us") }}

--- a/docs/site/_includes/macros/contact-us-form-wrapper.njk
+++ b/docs/site/_includes/macros/contact-us-form-wrapper.njk
@@ -1,8 +1,8 @@
 
 {% macro wrappedContactForm(pageSource) %}
-<div class="full-bleed-content-area get-involved form-background-light">
-<div class="get-involved-content">
-<div class="get-involved-content-form">
+<div class="full-bleed-content-area contact-us form-background-light">
+<div class="contact-us-content">
+<div class="contact-us-content-form">
 {%- from "macros/design-system-form.njk" import designSystemContact -%}
 {{ designSystemContact(pageSource) }}
 </div>

--- a/docs/site/_includes/macros/design-system-form.njk
+++ b/docs/site/_includes/macros/design-system-form.njk
@@ -19,32 +19,32 @@ data-response-error="<br/><strong>Uh oh!</strong> Looks like there was a problem
     <div class="form-field">
         <label for="role">Your main role</label>
         <div class="form-select">
-        <select id="role" name="role" data-airtable-field="Role">
-            <option disabled selected value="">
-                Select an option
-            </option>
-            <option value="Analytics">
-                Analytics
-            </option>
-            <option value="Content">
-                Content
-            </option>
-            <option value="Design">
-                Design
-            </option>
-            <option value="Development">
-                Development
-            </option>
-            <option value="Product">
-                Product
-            </option>
-            <option value="Research">
-                Research
-            </option>
-            <option value="Other">
-                Other
-            </option>
-        </select>
+            <select id="role" name="role" data-airtable-field="Role">
+                <option disabled selected value="">
+                    Select an option
+                </option>
+                <option value="Analytics">
+                    Analytics
+                </option>
+                <option value="Content">
+                    Content
+                </option>
+                <option value="Design">
+                    Design
+                </option>
+                <option value="Development">
+                    Development
+                </option>
+                <option value="Product">
+                    Product
+                </option>
+                <option value="Research">
+                    Research
+                </option>
+                <option value="Other">
+                    Other
+                </option>
+            </select>
         </div>
     </div>
     <div class="form-field">

--- a/docs/site/_includes/macros/design-system-form.njk
+++ b/docs/site/_includes/macros/design-system-form.njk
@@ -17,23 +17,29 @@ data-response-error="<br/><strong>Uh oh!</strong> Looks like there was a problem
         <input type="email" id="email" name="email" data-airtable-field="Email" placeholder="Email address" required>
     </div>
     <div class="form-field">
-        <label for="request">How can we help you?</label>
+        <label for="role">Your main role</label>
         <div class="form-select">
-        <select id="request" name="request" data-airtable-field="Request">
+        <select id="role" name="role" data-airtable-field="Role">
             <option disabled selected value="">
                 Select an option
             </option>
-            <option value="Send me updates on the Design System">
-                Send me updates on the Design System
+            <option value="Analytics">
+                Analytics
             </option>
-            <option value="I need help getting started">
-                I need help getting started
+            <option value="Content">
+                Content
             </option>
-            <option value="I want to collaborate">
-                I want to collaborate
+            <option value="Design">
+                Design
             </option>
-            <option value="I want to report a bug or give feedback">
-                I want to report a bug or give feedback
+            <option value="Development">
+                Development
+            </option>
+            <option value="Product">
+                Product
+            </option>
+            <option value="Research">
+                Research
             </option>
             <option value="Other">
                 Other
@@ -42,38 +48,7 @@ data-response-error="<br/><strong>Uh oh!</strong> Looks like there was a problem
         </div>
     </div>
     <div class="form-field">
-        <label for="about-yourself">About yourself</label>
-        <div class="form-select">
-        <select id="about-yourself" name="about-yourself" data-airtable-field="About yourself">
-            <option disabled selected value="">
-                Select an option
-            </option>
-            <option value="Content designer">
-                Content designer
-            </option>
-            <option value="Engineer">
-                Engineer
-            </option>
-            <option value="Developer">
-                Developer
-            </option>
-            <option value="Designer">
-                Designer
-            </option>
-            <option value="UX Researcher">
-                UX Researcher
-            </option>
-            <option value="Product owner">
-                Product owner
-            </option>
-            <option value="Other">
-                Other
-            </option>
-        </select>
-        </div>
-    </div>
-    <div class="form-field">
-        <label for="comments">What interests you about the design system?</label>
+        <label for="comments">How can we help?</label>
         <textarea id="comments" name="comments" data-airtable-field="Comments"></textarea>
     </div>
     <div class="hidden form-field">

--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -122,15 +122,15 @@ description: The California Design System makes it easy for state digital teams 
   <div class="full-bleed-content-area--block">
     <h2 class="d-block pt-1 mb-0">Be a part of the Design System</h2>
   </div>
-  <div class="full-bleed-content-area get-involved">
-    <div class="get-involved-content homepage-form">
+  <div class="full-bleed-content-area contact-us">
+    <div class="contact-us-content homepage-form">
       <p>We'd love to talk about how we can partner with you.</p>
-      <div class="get-involved-content-form">
+      <div class="contact-us-content-form">
       {%- from "macros/design-system-form.njk" import designSystemContact -%}
       {{ designSystemContact("Home page") }}
       </div>
     </div>
-    <div class="get-involved-image">
+    <div class="contact-us-image">
       <img src="/img/partner-design-system.svg" alt="abstract orrery">
     </div>
   </div>

--- a/docs/src/css/sass/feature-card-variations.scss
+++ b/docs/src/css/sass/feature-card-variations.scss
@@ -54,7 +54,7 @@
 .cagov-bold {
   font-weight: bold;
 }
-.get-involved {
+.contact-us {
   padding-top: 1rem;
   padding-bottom: 1.5rem;
   gap: 2rem;
@@ -92,18 +92,10 @@
   }
   select {
     appearance: none;
-    width: calc(100% + 1px);
-    
-    // background-image: url("data:image/svg+xml;utf8,<svg width='11' height='7' class='expanded-menu-section-header-arrow-svg' viewBox='0 0 11 7' fill='#004ABC' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M1.15596 0.204797L5.49336 5.06317L9.8545 0.204797C10.4293 -0.452129 11.4124 0.625368 10.813 1.28143L5.90083 6.82273C5.68519 7.05909 5.32606 7.05909 5.1342 6.82273L0.174341 1.28143C-0.400433 0.6245 0.581838 -0.452151 1.15661 0.204797H1.15596Z'></path></svg>");
-    // background-position: right 5px top 50%;
-
-    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='11' height='7' class='expanded-menu-section-header-arrow-svg' viewBox='0 0 11 7' fill='%23004ABC' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M1.15596 0.204797L5.49336 5.06317L9.8545 0.204797C10.4293 -0.452129 11.4124 0.625368 10.813 1.28143L5.90083 6.82273C5.68519 7.05909 5.32606 7.05909 5.1342 6.82273L0.174341 1.28143C-0.400433 0.6245 0.581838 -0.452151 1.15661 0.204797H1.15596Z'%3E%3C/path%3E%3C/svg%3E");
-    background-size: .6em;
-    background-position: calc(100% - 2.1rem) center;
-    background-repeat: no-repeat;
+    width: calc(100% + 3px);
   }
 
-  .get-involved-image img {
+  .contact-us-image img {
     object-fit: cover;
     width: 100%;
   }
@@ -127,7 +119,7 @@
     background: white;
     border-radius: 5px;
     &::after {
-      content: "∨";
+      // content: "∨";
       display: flex;
       align-items: center;
       justify-content: center;
@@ -139,6 +131,12 @@
       width: 2rem;
       font-weight: 900;
       pointer-events: none;
+
+
+      content: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='11' height='7' class='expanded-menu-section-header-arrow-svg' viewBox='0 0 11 7' fill='%23004ABC' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M1.15596 0.204797L5.49336 5.06317L9.8545 0.204797C10.4293 -0.452129 11.4124 0.625368 10.813 1.28143L5.90083 6.82273C5.68519 7.05909 5.32606 7.05909 5.1342 6.82273L0.174341 1.28143C-0.400433 0.6245 0.581838 -0.452151 1.15661 0.204797H1.15596Z'%3E%3C/path%3E%3C/svg%3E");
+      // background-size: .6em;
+      // background-position: calc(100% - 2.1rem) center;
+      // background-repeat: no-repeat;
     }
   }
 }
@@ -148,7 +146,7 @@ cagov-airtable-form .form-responded {
 }
 
 @media (max-width: 800px) {
-  .get-involved {
+  .contact-us {
     flex-wrap: wrap-reverse;
   }  
 }


### PR DESCRIPTION
* Change form fields to match updated spec Issue: Update contact us form fields. Simplify form. #574
* Fix mysterious issue with select box after noticing two selects on contact us page form.
* Rename CSS class for contact us form to "contact-us" instead of "get-involved"