### PR TITLE
Fix homepage title

### DIFF
--- a/docs/site/_data/eleventyComputed.js
+++ b/docs/site/_data/eleventyComputed.js
@@ -14,7 +14,11 @@ module.exports = {
   // Note that several metadata properties do not need to be in EleventyComputed.
   // See ./metadata.js for more.
   title: (article) => {
-    if ('title' in article && article.title !== '') {
+    if (
+      'title' in article &&
+      article.title !== '' &&
+      article.title !== defaults.site.name
+    ) {
       return `${article.title} | ${defaults.site.name}`;
     }
     return defaults.site.name;


### PR DESCRIPTION
Fixes the title on the homepage.

Titles on the site are appended with the site name. For example, if the article's title is "About", then "About | California Design System" is what appears in the `<title>` element.

However, on the homepage, the page title is the same as the site name. So you get "California Design System | California Design System".

This PR adds a check to ensure the page title and site name are not the same, before appending the site name.