### PR TITLE
Reset code demos

### DIFF
--- a/components/page-alert/readme.md
+++ b/components/page-alert/readme.md
@@ -35,18 +35,12 @@ Do not use page alerts to simply highlight important content. They are for infor
 
 ## Demo and sample markup
 
-<html-preview>
-
-```html preview
+```html preview reset
 <cagov-page-alert
   data-icon="ca-gov-icon-bell"
   data-message='Notice: DCC is soliciting proposals for the Local Jurisdiction Assistance Grant Program. <a href="#">Learn more</a>.'
 ></cagov-page-alert>
-
-
 ```
-
-</html-preview>
 
 ## Specs
 

--- a/docs/src/11ty/markdown.js
+++ b/docs/src/11ty/markdown.js
@@ -57,13 +57,15 @@ const scriptWrap = (js, hljsHtml) => `
  * The same HTML string that's formatted by highlight.js.
  * @returns {String} HTML
  */
-const previewWrap = (rawHtml, hljsHtml) => `
-  <div class="code-preview">
-    <div class="code-preview-demo">
-      ${rawHtml}
+const previewWrap = (rawHtml, hljsHtml, instructions) => `
+  <cagov-code-preview data-instructions="${instructions.join(',')}">
+    <div class="code-preview">
+      <div class="code-preview-demo">
+        ${rawHtml}
+      </div>
+      ${codeWrap(hljsHtml, 'HTML')}
     </div>
-    ${codeWrap(hljsHtml, 'HTML')}
-  </div>
+  </cagov-code-preview>
 `;
 
 /**
@@ -85,7 +87,7 @@ md.renderer.rules.fence = (tokens, idx) => {
 
   // info is the list of meta/labels supplied with the code block in markdown.
   const info = token.info ? md.utils.unescapeAll(token.info).trim() : '';
-  const [lang, instruction] = info.split(/\s+/g);
+  const [lang, command, ...instructions] = info.split(/\s+/g);
 
   // This is the raw code block as supplied in the markdown.
   const rawCode = token.content;
@@ -102,13 +104,13 @@ md.renderer.rules.fence = (tokens, idx) => {
       const highlightedCode = hljs.highlight(rawCode, hljsOptions).value;
 
       // This is a special JS preview block.
-      if (instruction === 'script') {
+      if (command === 'script') {
         return scriptWrap(rawCode, highlightedCode);
       }
 
       // This is a special HTML demo block.
-      if (instruction === 'preview') {
-        return previewWrap(rawCode, highlightedCode);
+      if (command === 'preview') {
+        return previewWrap(rawCode, highlightedCode, instructions);
       }
 
       // Remove the XML blurb when it's HTML. Highlight.js wrinkle.

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -196,6 +196,9 @@
     background-color: white;
     padding: 1rem;
   }
+  &-reset-button {
+    margin-bottom: 1rem;
+  }
   .code-block {
     margin-bottom: 0;
   }

--- a/docs/src/js/cagov-code-preview.js
+++ b/docs/src/js/cagov-code-preview.js
@@ -1,0 +1,30 @@
+class CaGovCodePreview extends window.HTMLElement {
+  constructor() {
+    super();
+
+    this.instructions = this.dataset.instructions.split(',');
+    this.allowReset = this.instructions.includes('reset');
+  }
+
+  connectedCallback() {
+    this.root = this.querySelector('.code-preview');
+    this.demo = this.querySelector('.code-preview-demo');
+
+    if (this.demo) {
+      this.originalCode = this.demo.innerHTML;
+    }
+
+    if (this.allowReset) {
+      const button = document.createElement('button');
+      button.classList.add('code-preview-reset-button');
+      button.innerHTML = 'Reset demo';
+      button.addEventListener('click', () => {
+        this.demo.innerHTML = this.originalCode;
+      });
+      
+      this.root.prepend(button);
+    }
+  }
+}
+
+window.customElements.define('cagov-code-preview', CaGovCodePreview);

--- a/docs/src/js/cagov-code-preview.js
+++ b/docs/src/js/cagov-code-preview.js
@@ -21,7 +21,7 @@ class CaGovCodePreview extends window.HTMLElement {
       button.addEventListener('click', () => {
         this.demo.innerHTML = this.originalCode;
       });
-      
+
       this.root.prepend(button);
     }
   }

--- a/docs/src/js/index.js
+++ b/docs/src/js/index.js
@@ -12,3 +12,4 @@ import '../../../components/back-to-top/src/index.js';
 
 import './component-sidebar.js';
 import './airtable-form/src/index.js';
+import './cagov-code-preview.js';


### PR DESCRIPTION
This PR adds an optional "Reset" button to code demos. This allows the reader to reset demos to an original state.

In particular, we need this for the page-alert demo, which disappears when closed. The reset button lets us bring that demo back after closing it.

<img width="818" alt="Screen Shot 2022-02-04 at 16 16 42" src="https://user-images.githubusercontent.com/1208960/152619781-0e2df2a4-a6ad-494e-9670-ea7648b29848.png">

This can be enabled in markdown by adding a `reset` instruction to the code block. For example:

````markdown
```html preview reset
<p>Demo here</p>
```
````

Closes #502.