### PR TITLE
Fix components menu

### DIFF
--- a/components/components.11tydata.js
+++ b/components/components.11tydata.js
@@ -33,17 +33,6 @@ module.exports = {
         changelog: matches.includes('changelog.md'),
       };
     },
-    title: (article) => {
-      const componentSlug = getComponentSlug(article);
-      const component = components[componentSlug];
-      // const filename = article.page.fileSlug;
-
-      if (component) {
-        return `${component.title} | ${defaults.site.name}`;
-      }
-
-      return defaults.site.name;
-    },
     description: (article) => {
       const componentSlug = getComponentSlug(article);
       const component = components[componentSlug];
@@ -55,6 +44,17 @@ module.exports = {
       return defaults.page.description;
     },
     metadata: {
+      page_title: (article) => {
+        const componentSlug = getComponentSlug(article);
+        const component = components[componentSlug];
+        // const filename = article.page.fileSlug;
+
+        if (component) {
+          return `${component.title} | ${defaults.site.name}`;
+        }
+
+        return defaults.site.name;
+      },
       social_image_path: (article) => {
         const componentSlug = getComponentSlug(article);
         const component = components[componentSlug];

--- a/components/page-navigation/CHANGELOG.md
+++ b/components/page-navigation/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Page navigation changelog
 
+## 2.1.1
+* Removed JS-based insertion of this widget below H1 on the page.
+
 ## 2.1.0
 * Renamed package from `ds-content-navigation` to `ds-page-navigation`.
 * Renamed custom element name from `<cagov-content-navigation>` to `<cagov-page-navigation>`.

--- a/components/page-navigation/dist/index.js
+++ b/components/page-navigation/dist/index.js
@@ -409,24 +409,3 @@ if (customElements.get('cagov-page-navigation') === undefined) {
 const style = document.createElement('style');
 style.textContent = styles;
 document.querySelector('head').appendChild(style);
-
-// Function determining if it's mobile view (max 767px)
-function mobileView() {
-  const mobileElement = document.querySelector('.branding .grid-mobile-icons');
-  if (mobileElement) {
-    return getComputedStyle(mobileElement).display !== 'none';
-  }
-  return false;
-}
-
-function insertAfter(referenceNode, newNode) {
-  referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
-}
-const contentnav = document.querySelector('.sidebar-container');
-const h1Header = document.querySelector('h1');
-
-if (mobileView()) {
-  if (contentnav && h1Header) {
-    insertAfter(h1Header, contentnav);
-  }
-}

--- a/components/page-navigation/src/index.js
+++ b/components/page-navigation/src/index.js
@@ -412,24 +412,3 @@ if (customElements.get('cagov-page-navigation') === undefined) {
 const style = document.createElement('style');
 style.textContent = styles;
 document.querySelector('head').appendChild(style);
-
-// Function determining if it's mobile view (max 767px)
-function mobileView() {
-  const mobileElement = document.querySelector('.branding .grid-mobile-icons');
-  if (mobileElement) {
-    return getComputedStyle(mobileElement).display !== 'none';
-  }
-  return false;
-}
-
-function insertAfter(referenceNode, newNode) {
-  referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
-}
-const contentnav = document.querySelector('.sidebar-container');
-const h1Header = document.querySelector('h1');
-
-if (mobileView()) {
-  if (contentnav && h1Header) {
-    insertAfter(h1Header, contentnav);
-  }
-}

--- a/docs/pages/about.md
+++ b/docs/pages/about.md
@@ -3,7 +3,7 @@ title: About the Design System
 description: Learn about the vision, mission, and history of the California Design System.  
 keywords: about, about us, history, mission, vision
 ---
-# About the Design System
+
 <p class="text-lead">It can be challenging to connect government services to Californians who need them most. We have to consider a wide range of experiences, abilities, education, and technical literacy. With the State of California’s Design System, we help make digital information and services easier to use. The Design System increases equity, unity, compassion, and trust.</p>
 
 ## Our vision 

--- a/docs/pages/components.md
+++ b/docs/pages/components.md
@@ -6,8 +6,6 @@ description: Components are the structural elements of the California Design Sys
 
 {%- from "macros/component-card-list.njk" import componentCardList -%}
 
-# Components
-
 <p class="text-lead">Components are the structural elements of the Design System. They meet common user needs and can be reused across websites.</p>
 
 Our components are:

--- a/docs/pages/contact-us.md
+++ b/docs/pages/contact-us.md
@@ -4,8 +4,6 @@ title: Contact us
 description: Get help from the State of California Design System team, post questions, and share technical information with fellow developers.
 ---
 
-# Contact us
-
 <p class="text-lead">Have a question? Contact us for help with general inquiries, feedback, or bugs.</p>
 
 {%- from "macros/contact-us-form-wrapper.njk" import wrappedContactForm -%}

--- a/docs/pages/footnotes.md
+++ b/docs/pages/footnotes.md
@@ -1,4 +1,6 @@
-# Footnotes
+---
+title: Footnotes
+---
 
 <a name="footnote1"></a>
 1. To use `import`, files must be served from a [webserver](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_web_server) such as Apache, Nginx, or [http-server](https://www.npmjs.com/package/http-server). The `file://` protocol will cause CORS errors in some browsers.

--- a/docs/pages/front-matter.md
+++ b/docs/pages/front-matter.md
@@ -1,4 +1,6 @@
-# Article front matter
+---
+title: Article front matter
+---
 
 We can add data to articles through use of [front matter](https://www.11ty.dev/docs/data-frontmatter/). Here's a full example; all fields are optional.
 

--- a/docs/pages/get-started.md
+++ b/docs/pages/get-started.md
@@ -3,8 +3,6 @@ title: Get started
 description: Learn how you can get started with using the California Design System. 
 ---
 
-# Get started
-
 <p class="text-lead">What you need to know about the Design System depends on your role and discipline.</p> 
 
 ## Developers

--- a/docs/pages/guides.md
+++ b/docs/pages/guides.md
@@ -1,1 +1,3 @@
-# Guides
+---
+title: Guides
+---

--- a/docs/pages/markdown.md
+++ b/docs/pages/markdown.md
@@ -1,4 +1,6 @@
-# Markdown preview tests
+---
+title: Markdown preview tests
+---
 
 Here's a page for documenting and testing our markdown preview capabilities.
 

--- a/docs/pages/principles.md
+++ b/docs/pages/principles.md
@@ -6,8 +6,6 @@ description: The principles behind the California Design System.
 
 {%- from "macros/principles-page-item.njk" import principlesPageItem -%}
 
-# Principles
-
 <p class="text-lead">We’ve researched the needs of Californians and created these principles to help state departments create great websites, services, and products.</p>
 
 {{ principlesPageItem(editable.principles, 1) }}

--- a/docs/pages/style/content.md
+++ b/docs/pages/style/content.md
@@ -3,8 +3,6 @@ title: Content style guide
 description: The California Design System uses these principles to create great content.
 ---
 
-# Content style guide
-
 <p class="text-lead">Great content takes work. The good news is that anyone can do it.</p>
 
 ## Content principles

--- a/docs/pages/style/content/be-concise.md
+++ b/docs/pages/style/content/be-concise.md
@@ -3,8 +3,6 @@ title: Be concise
 description: Simple writing supports equal outcomes.
 ---
 
-# Be concise
-
 <p class="text-lead">Government content is notorious for being long and complicated. It does not have to be. Simple writing supports equal outcomes.</p>
 
 ## Standards

--- a/docs/pages/style/content/build-accessibility-from-start.md
+++ b/docs/pages/style/content/build-accessibility-from-start.md
@@ -3,8 +3,6 @@ title: Build in accessibility from the start
 description: Accessibility goes beyond the technical components of a website. It’s about including everyone who has a right to information.
 ---
 
-# Build in accessibility from the start
-
 <p class="text-lead">We write for all Californians, not most Californians.</p>
 
 We must create content that:

--- a/docs/pages/style/content/focus-on-user-needs-services.md
+++ b/docs/pages/style/content/focus-on-user-needs-services.md
@@ -3,8 +3,6 @@ title: Focus on user needs and services
 description: Give people what they need and direct them to services.
 ---
 
-# Focus on user needs and services
-
 <p class="text-lead">Give people what they need and direct them to services. Your website’s purpose is not to tell people what to think about the government or your agency.</p>
 
 ## Why this is important

--- a/docs/pages/style/content/meet-your-audience-where-they-are.md
+++ b/docs/pages/style/content/meet-your-audience-where-they-are.md
@@ -3,8 +3,6 @@ title: Meet your audience where they are
 description: Knowing who they are and what they need helps you design for them.
 ---
 
-# Meet your audience where they are
-
 <p class="text-lead">All your content is for someone. Knowing who they are and what they need helps you design for them.</p>
 
 ## Why this is important

--- a/docs/pages/style/content/organize-content-strategically.md
+++ b/docs/pages/style/content/organize-content-strategically.md
@@ -3,8 +3,6 @@ title: Organize content strategically
 description: Well-organized content helps readers find what they’re looking for.
 ---
 
-# Organize content strategically
-
 <p class="text-lead">Well-organized content helps readers find what they’re looking for.</p>
 
 ## Standards

--- a/docs/pages/style/content/write-in-plain-language.md
+++ b/docs/pages/style/content/write-in-plain-language.md
@@ -3,8 +3,6 @@ title: Write in plain language
 description: Do the hard work to make content simple for people to understand.
 ---
 
-# Write in plain language
-
 <p class="text-lead">We do the hard work to make content simple for people to understand.</p>
 
 ## Standards

--- a/docs/pages/style/content/write-with-conversational-official-voice.md
+++ b/docs/pages/style/content/write-with-conversational-official-voice.md
@@ -3,8 +3,6 @@ title: Write with a conversational and official voice
 description: Give reliable information with confidence.
 ---
 
-# Write with a conversational and official voice
-
 <p class="text-lead">Give reliable information with confidence.</p>
 
 ## Why this is important

--- a/docs/pages/style/design.md
+++ b/docs/pages/style/design.md
@@ -3,8 +3,6 @@ title: Visual design style guide
 description: These recommended approaches make California Design System websites visually appealing, easy to use, and accessible.
 ---
 
-# Visual design style guide
-
 <p class="text-lead">The visual design of the Design System is inspired by the <a href="/principles/">Design System principles</a>. Our recommended approaches will make your website visually appealing while still being easy to use and accessible. It includes guidelines that ensure your website is consistent with other websites using the Design System.</p>
 
 ## Our approach to visual design

--- a/docs/pages/technical-approach.md
+++ b/docs/pages/technical-approach.md
@@ -3,8 +3,6 @@ title: A different approach
 description: An introduction to the technical approach of the California Design System.
 ---
 
-# A different approach
-
 Design systems are often created as a single monolithic package. All parts, whether desired or not, come as a whole and the entire system is a dependency of the parent project.
 
 In contrast, the State of California’s Design System is a collection of independent components. With [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) as the base, they’re less likely to cause dependency issues or CSS conflicts. This means you can choose which ones you need. 

--- a/docs/site/_data/eleventyComputed.js
+++ b/docs/site/_data/eleventyComputed.js
@@ -13,18 +13,18 @@ const buildURL = (path, domain) => {
 module.exports = {
   // Note that several metadata properties do not need to be in EleventyComputed.
   // See ./metadata.js for more.
-  title: (article) => {
-    if (
-      'title' in article &&
-      article.title !== '' &&
-      article.title !== defaults.site.name
-    ) {
-      return `${article.title} | ${defaults.site.name}`;
-    }
-    return defaults.site.name;
-  },
   metadata: {
     canonical_url: (article) => buildURL(article.permalink, root),
+    page_title: (article) => {
+      if (
+        'title' in article &&
+        article.title !== '' &&
+        article.title !== defaults.site.name
+      ) {
+        return `${article.title} | ${defaults.site.name}`;
+      }
+      return defaults.site.name;
+    },
     page_description: (article) =>
       article.metadata?.page_description ||
       article?.description ||
@@ -35,10 +35,14 @@ module.exports = {
       defaults.page.description,
     open_graph_title: (article) =>
       article.metadata?.open_graph_title ||
+      article.metadata?.page_title ||
       article?.title ||
       defaults.page.title,
     twitter_title: (article) =>
-      article.metadata?.twitter_title || article?.title || defaults.page.title,
+      article.metadata?.twitter_title ||
+      article.metadata?.page_title ||
+      article?.title ||
+      defaults.page.title,
     keywords: (article) => {
       if (article?.keywords) {
         // Combine any article keywords with site default keywords.

--- a/docs/site/_includes/layouts/component-index.njk
+++ b/docs/site/_includes/layouts/component-index.njk
@@ -31,7 +31,7 @@
 {% endmacro %}
 
 {% block content %}
-  <main class="cagov-main">
+  <main id="body-content" class="cagov-main">
     <article id="post-{{ componentSlug }}-{{ page.fileSlug }}" class="cagov-article with-sidebar with-site-nav">
       {% block componentPageTitle %}
         <h1 class="page-title title-cell">

--- a/docs/site/_includes/layouts/component-index.njk
+++ b/docs/site/_includes/layouts/component-index.njk
@@ -31,46 +31,44 @@
 {% endmacro %}
 
 {% block content %}
-  <div id="page-container" class="with-sidebar has-sidebar-left page-container-ds component-page">
-    <div id="main-content" class="main-content-ds single-column">
-      <div class="ds-content-layout">
-        <div class="sidebar-container component-sidebar everylayout" style="z-index: 1;">
-          <button class="component-sidebar-menu-button">
-            <svg class="component-sidebar-menu-boxes" width="25" height="25" fill="#004abc" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-              <rect width="43" height="43" x="0" y="0" rx="10"/>
-              <rect width="43" height="43" x="57" y="0" rx="10"/>
-              <rect width="43" height="43" x="0" y="57" rx="10"/>
-              <rect width="43" height="43" x="57" y="57" rx="10"/>
-            </svg>
-            <span class="component-sidebar-menu-text">Components</span>
-            <svg width="11" height="7" class="component-sidebar-menu-arrow" viewBox="0 0 11 7" fill="#004abc" xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd"
-                d="M1.15596 0.204797L5.49336 5.06317L9.8545 0.204797C10.4293 -0.452129 11.4124 0.625368 10.813 1.28143L5.90083 6.82273C5.68519 7.05909 5.32606 7.05909 5.1342 6.82273L0.174341 1.28143C-0.400433 0.6245 0.581838 -0.452151 1.15661 0.204797H1.15596Z"
-              />
-            </svg>
-          </button>
-          <nav class="component-sidebar-menu-content" aria-label="Components Navigation" aria-hidden="false">
-            <p class="component-sidebar-heading">Structural components</p>
-            {{ sidebarComponentSection(componentSets.structural) }}
-            <p class="component-sidebar-heading">Navigation components</p>
-            {{ sidebarComponentSection(componentSets.navigation) }}
-            <p class="component-sidebar-heading">Visual components</p>
-            {{ sidebarComponentSection(componentSets.visual) }}
-            <p class="component-sidebar-heading">Content components</p>
-            {{ sidebarComponentSection(componentSets.content) }}
-          </nav>
-        </div>
-        <div class="everylayout">
-          <main id="body-content" class="main-primary">
-            <article id="post-{{ componentSlug }}-{{ page.fileSlug }}">
-              <div class="entry-content">
-                {{ content | safe }}
-              </div>
-            </article>
-            <span class="return-top hidden-print"></span>
-          </main>
-        </div>
+  <main class="cagov-main">
+    <article id="post-{{ componentSlug }}-{{ page.fileSlug }}" class="cagov-article with-sidebar with-site-nav">
+      {% block componentPageTitle %}
+        <h1 class="page-title title-cell">
+          {{ title | safe }}
+        </h1>
+      {% endblock %}
+
+      <div class="component-sidebar sidebar-cell" style="z-index: 1;">
+        <button class="component-sidebar-menu-button">
+          <svg class="component-sidebar-menu-boxes" width="25" height="25" fill="#004abc" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <rect width="43" height="43" x="0" y="0" rx="10"/>
+            <rect width="43" height="43" x="57" y="0" rx="10"/>
+            <rect width="43" height="43" x="0" y="57" rx="10"/>
+            <rect width="43" height="43" x="57" y="57" rx="10"/>
+          </svg>
+          <span class="component-sidebar-menu-text">Components</span>
+          <svg width="11" height="7" class="component-sidebar-menu-arrow" viewBox="0 0 11 7" fill="#004abc" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M1.15596 0.204797L5.49336 5.06317L9.8545 0.204797C10.4293 -0.452129 11.4124 0.625368 10.813 1.28143L5.90083 6.82273C5.68519 7.05909 5.32606 7.05909 5.1342 6.82273L0.174341 1.28143C-0.400433 0.6245 0.581838 -0.452151 1.15661 0.204797H1.15596Z"
+            />
+          </svg>
+        </button>
+        <nav class="component-sidebar-menu-content" aria-label="Components Navigation" aria-hidden="false">
+          <p class="component-sidebar-heading">Structural components</p>
+          {{ sidebarComponentSection(componentSets.structural) }}
+          <p class="component-sidebar-heading">Navigation components</p>
+          {{ sidebarComponentSection(componentSets.navigation) }}
+          <p class="component-sidebar-heading">Visual components</p>
+          {{ sidebarComponentSection(componentSets.visual) }}
+          <p class="component-sidebar-heading">Content components</p>
+          {{ sidebarComponentSection(componentSets.content) }}
+        </nav>
       </div>
-    </div>
-  </div>
+
+      <div class="cagov-content content-cell">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
 {% endblock %}

--- a/docs/site/_includes/layouts/component-page.njk
+++ b/docs/site/_includes/layouts/component-page.njk
@@ -5,3 +5,7 @@
   {% if has["use-cases"] %}<meta itemprop="additionalProperty" content="has:use-cases">{% endif %}
   {% if has["changelog"] %}<meta itemprop="additionalProperty" content="has:changelog">{% endif %}
 {% endblock %}
+
+{% block componentPageTitle %}
+{# Titles are in the markdown on component pages, so remove it from the template. #}
+{% endblock %}

--- a/docs/site/_includes/layouts/index.njk
+++ b/docs/site/_includes/layouts/index.njk
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>{{ title }}</title> 
+  <title>{{ metadata.page_title }}</title> 
   <link rel="preload" href="/fonts/publicsans-bold-webfont.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="/fonts/publicsans-regular-webfont.woff2" as="font" type="font/woff2" crossorigin />
   <meta charset="utf-8">

--- a/docs/site/_includes/layouts/page.njk
+++ b/docs/site/_includes/layouts/page.njk
@@ -1,27 +1,20 @@
 {% extends "layouts/index.njk" %}
 {% block content %}
-  <div id="page-container" class="with-sidebar has-sidebar-left page-container-ds">
-    <div id="main-content" class="main-content-ds single-column">
-      <div id="body-content"></div>
-      <div class="ds-content-layout">
-        <div class="sidebar-container everylayout" style="z-index: 1;">
-          <sidebar space="0" side="left">
-            {% block contentNavigation %}
-              {% include "page-navigation.njk" %}
-            {% endblock %}
-          </sidebar>
-        </div>
-        <div class="everylayout">
-          <main class="main-primary">
-            <article id="post-{{ page.fileSlug }}">
-              <div class="entry-content">
-                {{ content | safe }}
-              </div>
-            </article>
-            <span class="return-top hidden-print"></span>
-          </main>
-        </div>
+  <main class="cagov-main">
+    <article id="post-{{ page.fileSlug }}" class="cagov-article with-sidebar with-page-nav">
+      <h1 class="page-title title-cell">
+        {{ title | safe }}
+      </h1>
+      <div class="sidebar-container everylayout sidebar-cell" style="z-index: 1;">
+        <sidebar space="0" side="left">
+          {% block contentNavigation %}
+            {% include "page-navigation.njk" %}
+          {% endblock %}
+        </sidebar>
       </div>
-    </div>
-  </div>
+      <div class="cagov-content content-cell">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
 {% endblock %}

--- a/docs/site/_includes/layouts/page.njk
+++ b/docs/site/_includes/layouts/page.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/index.njk" %}
 {% block content %}
-  <main class="cagov-main">
+  <main id="body-content" class="cagov-main">
     <article id="post-{{ page.fileSlug }}" class="cagov-article with-sidebar with-page-nav">
       <h1 class="page-title title-cell">
         {{ title | safe }}

--- a/docs/site/_includes/layouts/single-column.njk
+++ b/docs/site/_includes/layouts/single-column.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/index.njk" %}
 {% block content %}
-  <main class="cagov-main">
+  <main id="body-content" class="cagov-main">
     <article id="post-{{ page.fileSlug }}" class="cagov-article with-single-column">
       <h1 class="page-title">
         {{ title | safe }}

--- a/docs/site/_includes/layouts/single-column.njk
+++ b/docs/site/_includes/layouts/single-column.njk
@@ -1,20 +1,13 @@
 {% extends "layouts/index.njk" %}
 {% block content %}
-  <div id="page-container" class="page-container-ds">
-    <div id="main-content" class="main-content-ds single-column">
-      <div class="breadcrumb"></div>
-      <div class="ds-content-layout">
-        <main class="main-primary">
-          <div id="body-content">
-            <article id="post-{{ page.fileSlug }}">
-              <div class="entry-content">
-                {{ content | safe }}
-              </div>
-            </article>
-            <span class="return-top hidden-print"></span>
-          </div>
-        </main>
+  <main class="cagov-main">
+    <article id="post-{{ page.fileSlug }}" class="cagov-article with-single-column">
+      <h1 class="page-title">
+        {{ title | safe }}
+      </h1>
+      <div class="cagov-content">
+        {{ content | safe }}
       </div>
-    </div>
-  </div>
+    </article>
+  </main>
 {% endblock %}

--- a/docs/src/11ty/development-stage-transform.js
+++ b/docs/src/11ty/development-stage-transform.js
@@ -67,7 +67,7 @@ module.exports = (html, outputPath) => {
     const component = components[componentSlug];
     if (component) {
       const $ = cheerio.load(result);
-      const h1 = $('div.entry-content h1:first-of-type');
+      const h1 = $('div.cagov-content h1:first-of-type');
       if (h1.length) {
         const metadata = {
           component,

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -107,6 +107,7 @@
     }
     &-arrow {
       display: inline-block;
+      transform: rotate(270deg)
     }
   }
 }

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -95,7 +95,10 @@
       display: none;
       align-items: center;
       column-gap: .75rem;
-      width: 100%
+      width: 100%;
+      border: none;
+      padding: 1rem;
+      border: none !important;
     }
     &-text {
       flex-grow: 1;
@@ -109,11 +112,16 @@
 }
 
 @media screen and (max-width: 767px) {
+  .component-sidebar {
+    border-bottom: 1px solid var(--gray-300,#e1e0e3) !important;
+    margin-bottom: 1rem;
+  }
   .component-sidebar-menu-button {
     display: flex;
   }
   .component-sidebar-menu-content {
-    margin: 32px 0;
+    margin: 1rem 0;
+    padding: 0 1rem;
     display: none;
   }
   .component-sidebar-menu-content-reveal {

--- a/docs/src/css/sass/ds-site-global.scss
+++ b/docs/src/css/sass/ds-site-global.scss
@@ -13,7 +13,7 @@
   }
 }
 /* fix h1 on markdown pages */
-.entry-content h1:first-of-type {
+.cagov-content h1:first-of-type {
   margin: 0;
   padding: 0 0 24px 0;
 }

--- a/docs/src/css/sass/index.scss
+++ b/docs/src/css/sass/index.scss
@@ -45,3 +45,5 @@
 
 /* Used on the visual design style guide page to for table and font demo styles */
 @import './design-guide-page';
+
+@import './layout';

--- a/docs/src/css/sass/layout.scss
+++ b/docs/src/css/sass/layout.scss
@@ -1,0 +1,60 @@
+.cagov-main {
+  max-width: var(--w-lg, 1176px);
+  margin: 0 auto;
+}
+
+.cagov-article {
+  margin: var(--s-4, 2rem) 0;
+  padding: 0 var(--s-2, 1rem);
+}
+
+.cagov-article.with-single-column {
+  max-width: var(--w-page-content, 876px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.cagov-article.with-sidebar {
+  display: grid;
+  column-gap: var(--s-6, 4rem);
+  grid-template-columns: 16rem minmax(0, 1fr);
+  grid-template-rows: auto;
+  grid-template-areas: 
+    "sidebar title"
+    "sidebar content";
+}
+
+.title-cell { grid-area: title; }
+.sidebar-cell { grid-area: sidebar; }
+.content-cell { grid-area: content; }
+
+@media only screen and (max-width: 767px) {
+  .cagov-article.with-sidebar {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
+  }
+  .cagov-article.with-page-nav {
+    grid-template-areas: 
+      "title"
+      "sidebar"
+      "content";
+    .cagov-content {
+      margin-top: var(--s-2, 1rem);
+    }
+  }
+  .cagov-article.with-site-nav {
+    padding: 0;
+    margin-top: 0;
+    grid-template-areas:
+      "sidebar" 
+      "title"
+      "content";
+    .cagov-content {
+      padding: 0 var(--s-2, 1rem);
+    }
+    .page-title {
+      padding-left: var(--s-2, 1rem);
+      padding-right: var(--s-2, 1rem);
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes #618, which is a re-do of #545. It also addresses #467 and #468.

Here's a summary of the challenge. 

* On regular pages with a sidebar, the sidebar needs to appear **under** the H1 on mobile.
* On component pages, the sidebar needs to appear **over** the H1 (as a menu) on mobile.

In the process of fixing the components menu, I wound up making some significant changes.

* There's a new version of the page-navigation component. The logic that auto-inserts `<cagov-page-navigation>` after the first H1 on mobile has been removed. 
* The H1s have been removed from markdown articles. These titles will now be rendered by the templates.
* Layouts for all pages (except the homepage) have been rewritten. I found using the DS layouts difficult for what I was trying to achieve; using grids was way easier.

Regarding #468, this is a partial fix. I still need to implement the "X" icon when the menu is open. But wanted to get this in before code freeze.

Closes #618, #467.