### PR TITLE
make the title fit on two lines on desktop per design request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# California Design System
+
+## 1.0.1
+
+* Add automated end to end tests using playwright that validate instances of all page templates with axe accessibility checks. These run against any opened PR via git action
+* Tweaks for design and content fixes
+* Some accessibility bugs on site fixed
+* Added reset feature to component demos
+
+## 1.0.0 
+
+* Initial release includes 18 components, principles, get started documentation, contact forms, design and content style guides. The component documentation is dynamically built from the component's readme doc and includes live interactive demos of the component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Tweaks for design and content fixes
 * Some accessibility bugs on site fixed
 * Added reset feature to component demos
+* Component folder names updated for consistency along with npm package names, custom element names and css classes
+* Page titles now pulled from meta data
 
 ## 1.0.0 
 

--- a/docs/src/css/sass/feature-card-variations.scss
+++ b/docs/src/css/sass/feature-card-variations.scss
@@ -48,6 +48,11 @@
     max-width: 40%;
   }  
 }
+.cagov-featured-sidebar {
+  h1 { 
+    padding-bottom: var(--s-2,1rem)
+  }
+}
 
 /* utility classes added for this section */
 .cagov-mt-2 {

--- a/docs/src/css/sass/feature-card-variations.scss
+++ b/docs/src/css/sass/feature-card-variations.scss
@@ -42,6 +42,13 @@
   min-height: 5rem;
 }
 
+/* The title on the homepage is long and needs more space as an H1 */
+@media (min-width: 1176px) {
+  .cagov-featured-sidebar {
+    max-width: 40%;
+  }  
+}
+
 /* utility classes added for this section */
 .cagov-mt-2 {
   margin-top: 1.5rem;


### PR DESCRIPTION
This fixes a bug I introduced during the 1.0.1 release:

I made the header in the feature card on the homepage an H1 instead of an H2 because an H1 is required to pass accessibility audits. This created a design bug because the header was bigger.

Changing width of feature card width on desktop per @kmbrlygl's recommendation so the H1 has enough space to fit on 2 lines