### PR TITLE
patch candidate: restrict wider feature card to header on homepage wi…

### DIFF
--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -7,7 +7,7 @@ description: The California Design System makes it easy for state digital teams 
 <div class="full-bleed full-bleed--highlight1">
   <div class="full-bleed-content-area wp-block-ca-design-system-hero cagov-with-sidebar cagov-with-sidebar-left cagov-featured-section cagov-bkgrd-gry cagov-block wp-block-cagov-hero">
     <div>
-      <div class="cagov-stack p-b-3 cagov-featured-sidebar">
+      <div class="cagov-stack p-b-3 cagov-featured-sidebar max-w-40">
         <h1 class="m-t-3">Meet the California Design System</h1>
         <div class="cagov-hero-body-content">
           <p>The Design System makes it easy for state digital teams to build accessible, consistent, and performant services and products to meet Californians’ needs.</p>

--- a/docs/src/css/sass/feature-card-variations.scss
+++ b/docs/src/css/sass/feature-card-variations.scss
@@ -44,7 +44,7 @@
 
 /* The title on the homepage is long and needs more space as an H1 */
 @media (min-width: 1176px) {
-  .cagov-featured-sidebar {
+  .cagov-featured-sidebar.max-w-40 {
     max-width: 40%;
   }  
 }


### PR DESCRIPTION
…th additional class

This change is a patch releaes for 1.0.1 that fixes unintentional widening of the spacing of the 3rd section in the homepage that also uses the feature card layout by adding a specific class to the feature card that changes its desktop width