### PR TITLE
Fix color contrast of dev stage tracker

### DIFF
--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -171,7 +171,7 @@
       &.current-development-stage {
         dt {
           background-color: var(--secondary-color, #FF8000);
-          color: #000;
+          color: var(--black, #000000);
         }
         font-weight: 700;
       }

--- a/docs/src/css/sass/component-page.scss
+++ b/docs/src/css/sass/component-page.scss
@@ -171,7 +171,7 @@
       &.current-development-stage {
         dt {
           background-color: var(--secondary-color, #FF8000);
-          color: white;
+          color: #000;
         }
         font-weight: 700;
       }


### PR DESCRIPTION
This PR fixes the a color contrast problem on the **Development stage** section of our component pages.

Closes #631 