### PR TITLE
Fix button for code reset

### DIFF
--- a/docs/src/js/cagov-code-preview.js
+++ b/docs/src/js/cagov-code-preview.js
@@ -17,6 +17,7 @@ class CaGovCodePreview extends window.HTMLElement {
     if (this.allowReset) {
       const button = document.createElement('button');
       button.classList.add('code-preview-reset-button');
+      button.classList.add('btn-primary');
       button.innerHTML = 'Reset demo';
       button.addEventListener('click', () => {
         this.demo.innerHTML = this.originalCode;


### PR DESCRIPTION
Fixes a style regression on the reset button for code demos.

<img width="853" alt="Screen Shot 2022-02-16 at 09 23 48" src="https://user-images.githubusercontent.com/1208960/154321049-87dafec8-7a39-4137-bb11-aea9b66d177f.png">

This does change the color of the button from before. I imagine we'll be changing this again pending work on #662 and/or #627. But this feels fine for now.

Closes #502.