### PR TITLE
Fix page-navigation post-click focus

### DIFF
--- a/components/page-navigation/CHANGELOG.md
+++ b/components/page-navigation/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Page navigation changelog
 
+## 2.1.2
+* Ensure the browser's focus follows the link, for accessibility purposes.
+
 ## 2.1.1
 * Removed JS-based insertion of this widget below H1 on the page.
 

--- a/components/page-navigation/dist/index.js
+++ b/components/page-navigation/dist/index.js
@@ -312,6 +312,8 @@ class CAGovPageNavigation extends window.HTMLElement {
               top: position.top - 200,
             });
 
+            target.focus();
+
             window.history.pushState(null, null, hashval);
           }
         } catch (error) {

--- a/components/page-navigation/package-lock.json
+++ b/components/page-navigation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-page-navigation",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-page-navigation",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "rollup-plugin-import-css": "^3.0.2"

--- a/components/page-navigation/package.json
+++ b/components/page-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-page-navigation",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/components/page-navigation/src/index.js
+++ b/components/page-navigation/src/index.js
@@ -311,6 +311,8 @@ class CAGovPageNavigation extends window.HTMLElement {
               top: position.top - 200,
             });
 
+            target.focus();
+
             window.history.pushState(null, null, hashval);
           }
         } catch (error) {


### PR DESCRIPTION
When clicking on a link in the page-navigation component, we expect the page to scroll to the linked section.  The browser's focus should also shift to the linked content. However, the latter is not happening. The focus stays inside the page-navigation component, even after the page scrolls to the desired section.

This is an accessibility problem for those who use keyboard navigation. They're unable to interact with the linked section of the page because the browser focus stays inside page-navigation.

This PR aims to fix that. 

Note: this new version of the page-navigation component will need to be published to npm upon merge into `main`.

Closes #661.