### PR TITLE
sample markup updates: h1 and no lazy loading

### DIFF
--- a/components/feature-card/CHANGELOG.md
+++ b/components/feature-card/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Feature card changelog
+## 1.0.6
+* Remove loading="lazy" attribute from main image because it is usually above the fold and should not have any display delays
+* Use an H1 instead of h2 in the sample markup because the feature card usually holds the most important page header
 
 ## 1.0.5
 * Limit the h3 definition to .cagov-featured-section, so it doesn't reset all h3 across the site.

--- a/components/feature-card/package.json
+++ b/components/feature-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-feature-card",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "This is a design for featuring important content at the top of a page. The layout uses a sidebar pattern with the text elements: header, description and call to action button on the left and an image on the right. On smaller screens the image appears above the text.",
   "main": "index.css",  
   "type": "module",

--- a/components/feature-card/readme.md
+++ b/components/feature-card/readme.md
@@ -42,7 +42,7 @@ Do not put a lot of content in your feature card. Too much content is hard to re
 >
   <div>
     <div class="cagov-stack cagov-p-2 cagov-featured-sidebar">
-      <h2>We’re making changes to better serve you</h2>
+      <h1>We’re making changes to better serve you</h1>
       <div class="cagov-hero-body-content">
         <p>
           California has merged the three state cannabis authorities into
@@ -52,7 +52,7 @@ Do not put a lot of content in your feature card. Too much content is hard to re
         <div class="wp-block-button">
           <a
             class="wp-block-button__link"
-            href="#"
+            href="https://cannabis.ca.gov/about-us/consolidation/"
             >Learn more</a
           >
         </div>
@@ -60,7 +60,6 @@ Do not put a lot of content in your feature card. Too much content is hard to re
     </div>
     <div>
       <img
-        loading="lazy"
         class="cagov-featured-image"
         src="https://cannabis.ca.gov/wp-content/uploads/sites/2/2021/06/cannabis-buds-hero-1024x683.jpg"
         alt=""

--- a/components/feature-card/template.html
+++ b/components/feature-card/template.html
@@ -3,7 +3,7 @@
 >
   <div>
     <div class="cagov-stack cagov-p-2 cagov-featured-sidebar">
-      <h2>We’re making changes to better serve you</h2>
+      <h1>We’re making changes to better serve you</h1>
       <div class="cagov-hero-body-content">
         <p>
           California has merged the three state cannabis authorities into
@@ -21,7 +21,6 @@
     </div>
     <div>
       <img
-        loading="lazy"
         class="cagov-featured-image"
         src="https://cannabis.ca.gov/wp-content/uploads/sites/2/2021/06/cannabis-buds-hero-1024x683.jpg"
         alt=""


### PR DESCRIPTION
Changes to sample markup:
- Do not use loading="lazy" because this is designed to be an above the fold image
- Use h1 instead of h2 for the header in the feature card because in all our use cases so far this has been appropriate and gets caught in axe accessibility audits