### PR TITLE
Fix PR previews to support capitalized branches

### DIFF
--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_ENV
       - name: Escape branch name for URL
         shell: bash
-        run: echo "URLSAFE_BRANCH_NAME=$(echo ${BRANCH_NAME} | sed 's|[^A-Za-z0-9-]|-|g' | sed -E 's|-*([A-Za-z0-9]*.*[A-Za-z0-9]+)-*|\1|')" >> $GITHUB_ENV
+        run: echo "URLSAFE_BRANCH_NAME=$(echo ${BRANCH_NAME} | sed 's|[^A-Za-z0-9-]|-|g' | sed -E 's|-*([A-Za-z0-9]*.*[A-Za-z0-9]+)-*|\1|' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Report escaped branch name
         shell: bash
         run: echo ${URLSAFE_BRANCH_NAME}


### PR DESCRIPTION
This addresses the broken PR preview site in #692. Explanation from Slack:

> Looks like it's breaking because of the capitalized "README" in the branch name. The site is getting uploaded to S3 with the caps. But Cloudfront strips away the caps upon request. Hence, breakage. Cloudfront can't find the correct folder in S3. The messy part is that Cloudfront isn't wrong. Non-IDN domain names are case-insensitive. This means we'll need to rewrite some parts of this set-up to remove the caps from the S3 folder and the PR subdomain.

I'm putting this PR against `main` at this time; I don't want to lose track of this fix despite code freeze on our current release. We can move this to target another branch when we're ready to release it, if needed.