### PR TITLE
Bump header

### DIFF
--- a/components/statewide-header/package-lock.json
+++ b/components/statewide-header/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-statewide-header",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "devDependencies": {
         "sass": "^1.37.5"

--- a/components/statewide-header/package.json
+++ b/components/statewide-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "index.css",
   "type": "module",


### PR DESCRIPTION
We had bug fixes pushed in the last release for the statewide header component by outside contributors. Those updates took effect on the design system site because that site uses component source files in this repo.

The outside contributors won't have permission to republish our npm packages so I have done so

No code changes, just minor version bump the package and run the publish command which will
- Write updated files to our CDN at a version specific path
- Publish the latest version of the module to npm

The changelog already had info about the bugfix with this version number