### PR TITLE
A11y mav menu aria expanded

### DIFF
--- a/components/site-navigation/CHANGELOG.md
+++ b/components/site-navigation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Site navigation changelog
 
+## 2.1.4
+* Accessibility fix: Use aria-expanded on the button that controls the expansion, add aria-controls to the suggested html to match the id of the expanding element
 
 ## 2.1.3
 * Updated color variables to go inline with new CEILAB color palette

--- a/components/site-navigation/README.md
+++ b/components/site-navigation/README.md
@@ -82,7 +82,7 @@ Do not link to PDFs in the site navigation.
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu1-links">
                 <span>
                   Applicants
                 </span>
@@ -97,7 +97,7 @@ Do not link to PDFs in the site navigation.
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu1-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/applicants/how-to-apply-renew/" tabindex="-1">How to apply for or renew a license</a>
               
@@ -116,7 +116,7 @@ Do not link to PDFs in the site navigation.
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu2-links">
                 <span>
                   Licensees
                 </span>
@@ -131,7 +131,7 @@ Do not link to PDFs in the site navigation.
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu2-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/licensees/cultivation/" tabindex="-1">Cultivation</a>
               
@@ -156,7 +156,7 @@ Do not link to PDFs in the site navigation.
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu3-links">
                 <span>
                   Consumers
                 </span>
@@ -171,7 +171,7 @@ Do not link to PDFs in the site navigation.
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu3-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/consumers/whats-legal/" tabindex="-1">What’s legal</a>
               
@@ -188,7 +188,7 @@ Do not link to PDFs in the site navigation.
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu4-links">
                 <span>
                   Resources
                 </span>
@@ -203,7 +203,7 @@ Do not link to PDFs in the site navigation.
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu4-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/resources/laws-and-regulations/" tabindex="-1">Laws and regulations</a>
               
@@ -222,7 +222,7 @@ Do not link to PDFs in the site navigation.
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu5-links">
                 <span>
                   About us
                 </span>
@@ -237,7 +237,7 @@ Do not link to PDFs in the site navigation.
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu5-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/about-us/about-dcc/" tabindex="-1">About DCC</a>
               

--- a/components/site-navigation/dist/index.js
+++ b/components/site-navigation/dist/index.js
@@ -182,8 +182,15 @@ class CAGovSiteNavigation extends window.HTMLElement {
     allMenus.forEach((menu) => {
       const expandedEl = menu.querySelector('.expanded-menu-section');
       expandedEl.classList.remove('expanded');
-      menu.setAttribute('aria-expanded', 'false');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
+      if (
+        closestDropDown.id &&
+        menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
+      ) {
+        menu
+          .querySelector(`button[aria-controls=${closestDropDown.id}]`)
+          .setAttribute('aria-expanded', 'false');
+      }
       if (closestDropDown) {
         closestDropDown.setAttribute('aria-hidden', 'true');
         const allLinks = closestDropDown.querySelectorAll('a');
@@ -204,7 +211,16 @@ class CAGovSiteNavigation extends window.HTMLElement {
         );
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
-          menu.setAttribute('aria-expanded', 'false');
+          if (
+            nearestMenuDropDown.id &&
+            menu.querySelector(
+              `button[aria-controls=${nearestMenuDropDown.id}]`,
+            )
+          ) {
+            menu
+              .querySelector(`button[aria-controls=${nearestMenuDropDown.id}]`)
+              .setAttribute('aria-expanded', 'false');
+          }
         }
       }
       const menuComponent = this;
@@ -220,10 +236,17 @@ class CAGovSiteNavigation extends window.HTMLElement {
           } else {
             menuComponent.closeAllMenus();
             expandedEl.classList.add('expanded');
-            menu.setAttribute('aria-expanded', 'true');
             const closestDropDown = this.querySelector(
               '.expanded-menu-dropdown',
             );
+            if (
+              closestDropDown.id &&
+              menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
+            ) {
+              menu
+                .querySelector(`button[aria-controls=${closestDropDown.id}]`)
+                .setAttribute('aria-expanded', 'true');
+            }
             if (closestDropDown) {
               closestDropDown.setAttribute('aria-hidden', 'false');
               const allLinks = closestDropDown.querySelectorAll('a');

--- a/components/site-navigation/dist/index.js
+++ b/components/site-navigation/dist/index.js
@@ -184,6 +184,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
       expandedEl.classList.remove('expanded');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
       if (
+        closestDropDown &&
         closestDropDown.id &&
         menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
       ) {
@@ -212,6 +213,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
           if (
+            nearestMenuDropDown &&
             nearestMenuDropDown.id &&
             menu.querySelector(
               `button[aria-controls=${nearestMenuDropDown.id}]`,
@@ -240,6 +242,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
               '.expanded-menu-dropdown',
             );
             if (
+              closestDropDown &&
               closestDropDown.id &&
               menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
             ) {

--- a/components/site-navigation/package.json
+++ b/components/site-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-site-navigation",
-  "version": "2.1.3-beta.1",
+  "version": "2.1.4",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/components/site-navigation/package.json
+++ b/components/site-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-site-navigation",
-  "version": "2.1.3",
+  "version": "2.1.3-beta.1",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/components/site-navigation/src/index.js
+++ b/components/site-navigation/src/index.js
@@ -184,7 +184,8 @@ class CAGovSiteNavigation extends window.HTMLElement {
       expandedEl.classList.remove('expanded');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
       if (
-        closestDropDown && closestDropDown.id &&
+        closestDropDown &&
+        closestDropDown.id &&
         menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
       ) {
         menu
@@ -212,7 +213,8 @@ class CAGovSiteNavigation extends window.HTMLElement {
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
           if (
-            nearestMenuDropDown && nearestMenuDropDown.id &&
+            nearestMenuDropDown &&
+            nearestMenuDropDown.id &&
             menu.querySelector(
               `button[aria-controls=${nearestMenuDropDown.id}]`,
             )
@@ -240,7 +242,8 @@ class CAGovSiteNavigation extends window.HTMLElement {
               '.expanded-menu-dropdown',
             );
             if (
-              closestDropDown && closestDropDown.id &&
+              closestDropDown &&
+              closestDropDown.id &&
               menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
             ) {
               menu

--- a/components/site-navigation/src/index.js
+++ b/components/site-navigation/src/index.js
@@ -182,8 +182,10 @@ class CAGovSiteNavigation extends window.HTMLElement {
     allMenus.forEach((menu) => {
       const expandedEl = menu.querySelector('.expanded-menu-section');
       expandedEl.classList.remove('expanded');
-      menu.setAttribute('aria-expanded', 'false');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
+      if(closestDropDown.id && menu.querySelector('button[aria-controls='+closestDropDown.id+']')) {
+        menu.querySelector('button[aria-controls='+closestDropDown.id+']').setAttribute('aria-expanded', 'false');
+      }
       if (closestDropDown) {
         closestDropDown.setAttribute('aria-hidden', 'true');
         const allLinks = closestDropDown.querySelectorAll('a');
@@ -204,7 +206,9 @@ class CAGovSiteNavigation extends window.HTMLElement {
         );
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
-          menu.setAttribute('aria-expanded', 'false');
+          if(nearestMenuDropDown.id && menu.querySelector('button[aria-controls='+nearestMenuDropDown.id+']')) {
+            menu.querySelector('button[aria-controls='+nearestMenuDropDown.id+']').setAttribute('aria-expanded', 'false');
+          }
         }
       }
       const menuComponent = this;
@@ -220,10 +224,12 @@ class CAGovSiteNavigation extends window.HTMLElement {
           } else {
             menuComponent.closeAllMenus();
             expandedEl.classList.add('expanded');
-            menu.setAttribute('aria-expanded', 'true');
             const closestDropDown = this.querySelector(
               '.expanded-menu-dropdown',
             );
+            if(closestDropDown.id && menu.querySelector('button[aria-controls='+closestDropDown.id+']')) {
+              menu.querySelector('button[aria-controls='+closestDropDown.id+']').setAttribute('aria-expanded', 'true');
+            }  
             if (closestDropDown) {
               closestDropDown.setAttribute('aria-hidden', 'false');
               const allLinks = closestDropDown.querySelectorAll('a');

--- a/components/site-navigation/src/index.js
+++ b/components/site-navigation/src/index.js
@@ -183,8 +183,13 @@ class CAGovSiteNavigation extends window.HTMLElement {
       const expandedEl = menu.querySelector('.expanded-menu-section');
       expandedEl.classList.remove('expanded');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
-      if(closestDropDown.id && menu.querySelector('button[aria-controls='+closestDropDown.id+']')) {
-        menu.querySelector('button[aria-controls='+closestDropDown.id+']').setAttribute('aria-expanded', 'false');
+      if (
+        closestDropDown.id &&
+        menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
+      ) {
+        menu
+          .querySelector(`button[aria-controls=${closestDropDown.id}]`)
+          .setAttribute('aria-expanded', 'false');
       }
       if (closestDropDown) {
         closestDropDown.setAttribute('aria-hidden', 'true');
@@ -206,8 +211,15 @@ class CAGovSiteNavigation extends window.HTMLElement {
         );
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
-          if(nearestMenuDropDown.id && menu.querySelector('button[aria-controls='+nearestMenuDropDown.id+']')) {
-            menu.querySelector('button[aria-controls='+nearestMenuDropDown.id+']').setAttribute('aria-expanded', 'false');
+          if (
+            nearestMenuDropDown.id &&
+            menu.querySelector(
+              `button[aria-controls=${nearestMenuDropDown.id}]`,
+            )
+          ) {
+            menu
+              .querySelector(`button[aria-controls=${nearestMenuDropDown.id}]`)
+              .setAttribute('aria-expanded', 'false');
           }
         }
       }
@@ -227,9 +239,14 @@ class CAGovSiteNavigation extends window.HTMLElement {
             const closestDropDown = this.querySelector(
               '.expanded-menu-dropdown',
             );
-            if(closestDropDown.id && menu.querySelector('button[aria-controls='+closestDropDown.id+']')) {
-              menu.querySelector('button[aria-controls='+closestDropDown.id+']').setAttribute('aria-expanded', 'true');
-            }  
+            if (
+              closestDropDown.id &&
+              menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
+            ) {
+              menu
+                .querySelector(`button[aria-controls=${closestDropDown.id}]`)
+                .setAttribute('aria-expanded', 'true');
+            }
             if (closestDropDown) {
               closestDropDown.setAttribute('aria-hidden', 'false');
               const allLinks = closestDropDown.querySelectorAll('a');

--- a/components/site-navigation/src/index.js
+++ b/components/site-navigation/src/index.js
@@ -184,7 +184,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
       expandedEl.classList.remove('expanded');
       const closestDropDown = menu.querySelector('.expanded-menu-dropdown');
       if (
-        closestDropDown.id &&
+        closestDropDown && closestDropDown.id &&
         menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
       ) {
         menu
@@ -212,7 +212,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
         if (nearestMenuDropDown) {
           nearestMenuDropDown.setAttribute('aria-hidden', 'true');
           if (
-            nearestMenuDropDown.id &&
+            nearestMenuDropDown && nearestMenuDropDown.id &&
             menu.querySelector(
               `button[aria-controls=${nearestMenuDropDown.id}]`,
             )
@@ -240,7 +240,7 @@ class CAGovSiteNavigation extends window.HTMLElement {
               '.expanded-menu-dropdown',
             );
             if (
-              closestDropDown.id &&
+              closestDropDown && closestDropDown.id &&
               menu.querySelector(`button[aria-controls=${closestDropDown.id}]`)
             ) {
               menu

--- a/components/site-navigation/template.html
+++ b/components/site-navigation/template.html
@@ -48,7 +48,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu1-links">
                 <span>
                   Applicants
                 </span>
@@ -63,7 +63,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu1-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/applicants/how-to-apply-renew/" tabindex="-1">How to apply for or renew a license</a>
               
@@ -82,7 +82,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu2-links">
                 <span>
                   Licensees
                 </span>
@@ -97,7 +97,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu2-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/licensees/cultivation/" tabindex="-1">Cultivation</a>
               
@@ -122,7 +122,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu3-links">
                 <span>
                   Consumers
                 </span>
@@ -137,7 +137,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu3-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/consumers/whats-legal/" tabindex="-1">What’s legal</a>
               
@@ -154,7 +154,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu4-links">
                 <span>
                   Resources
                 </span>
@@ -169,7 +169,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu4-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/resources/laws-and-regulations/" tabindex="-1">Laws and regulations</a>
               
@@ -188,7 +188,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu5-links">
                 <span>
                   About us
                 </span>
@@ -203,7 +203,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu5-links">
               
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/about-us/about-dcc/" tabindex="-1">About DCC</a>
               

--- a/components/site-navigation/test/index.js
+++ b/components/site-navigation/test/index.js
@@ -40,7 +40,9 @@ describe('Site navigation', function unitTest() {
 
     // verify attribute expected to change on click is in the initial off state
     expect(
-      el.querySelector('.expanded-menu-col button').getAttribute('aria-expanded'),
+      el
+        .querySelector('.expanded-menu-col button')
+        .getAttribute('aria-expanded'),
     ).to.equal('false');
 
     // click to expand menu
@@ -48,7 +50,9 @@ describe('Site navigation', function unitTest() {
 
     // verify attribute is changed as expected after click
     expect(
-      el.querySelector('.expanded-menu-col button').getAttribute('aria-expanded'),
+      el
+        .querySelector('.expanded-menu-col button')
+        .getAttribute('aria-expanded'),
     ).to.equal('true');
   });
 });

--- a/components/site-navigation/test/index.js
+++ b/components/site-navigation/test/index.js
@@ -40,7 +40,7 @@ describe('Site navigation', function unitTest() {
 
     // verify attribute expected to change on click is in the initial off state
     expect(
-      el.querySelector('.expanded-menu-col').getAttribute('aria-expanded'),
+      el.querySelector('.expanded-menu-col button').getAttribute('aria-expanded'),
     ).to.equal('false');
 
     // click to expand menu
@@ -48,7 +48,7 @@ describe('Site navigation', function unitTest() {
 
     // verify attribute is changed as expected after click
     expect(
-      el.querySelector('.expanded-menu-col').getAttribute('aria-expanded'),
+      el.querySelector('.expanded-menu-col button').getAttribute('aria-expanded'),
     ).to.equal('true');
   });
 });

--- a/components/statewide-header/package-lock.json
+++ b/components/statewide-header/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/ds-statewide-header",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "devDependencies": {
         "sass": "^1.37.5"

--- a/components/statewide-header/package.json
+++ b/components/statewide-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-statewide-header",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "index.css",
   "type": "module",

--- a/docs/site/_includes/site-navigation.njk
+++ b/docs/site/_includes/site-navigation.njk
@@ -40,7 +40,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu1-links">
                 <span>
                   Style guides
                 </span>
@@ -55,7 +55,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu1-links">
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/style/content/" tabindex="-1">Content style guide</a>              
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/style/design/" tabindex="-1">Design style guide</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/style/tokens/" tabindex="-1">Design tokens</a>
@@ -66,7 +66,7 @@
         <div class="expanded-menu-col js-cagov-navoverlay-expandable">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <button class="expanded-menu-section-header-link js-event-hm-menu">
+              <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu2-links">
                 <span>
                   Components
                 </span>
@@ -81,7 +81,7 @@
                 </span>
               </button>
             </strong>
-            <div class="expanded-menu-dropdown">
+            <div class="expanded-menu-dropdown" id="menu2-links">
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/components/" tabindex="-1">All components</a>              
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/why-web-components/" tabindex="-1">Why web components</a>
             </div>
@@ -106,7 +106,7 @@
           <div class="expanded-menu-col js-cagov-navoverlay-expandable">
             <div class="expanded-menu-section">
               <strong class="expanded-menu-section-header">
-                <button class="expanded-menu-section-header-link js-event-hm-menu">
+                <button class="expanded-menu-section-header-link js-event-hm-menu" aria-controls="menu3-links">
                   <span>
                     Dev
                   </span>
@@ -121,7 +121,7 @@
                   </span>
                 </button>
               </strong>
-              <div class="expanded-menu-dropdown">
+              <div class="expanded-menu-dropdown" id="menu3-links">
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/markdown/" tabindex="-1">Markdown</a>
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/front-matter/" tabindex="-1">Front Matter</a>
               </div>


### PR DESCRIPTION
This change is a result of axe-accessibility checker flagging inappropriate use of aria-expanded when using the ds-site-navigation component on the digital.ca.gov site.

It looks like the expected use is to use that attribute on a button element that controls the expansion and collapse. I have added aria-controls to the button in the sample html to match ids on the expanding sections

Referred to docs: https://www.w3.org/WAI/GL/wiki/Using_the_WAI-ARIA_aria-expanded_state_to_mark_expandable_and_collapsible_regions