### PR TITLE
updating accordion docs inside the design system without bumping version

### DIFF
--- a/components/accordion/README.md
+++ b/components/accordion/README.md
@@ -41,9 +41,9 @@ Accordions hide information unless someone opens them. This requires an extra ac
   <details>
     <summary>Title 1</summary>
     <div class="accordion-body">
-      <p>A couple buttons are included inside this accordion to demonstrate that when the accordion is closed they are automatically not in the keyboard focus order but when the accordion opens they become the next available elements in the keyboard navigation sequence after the accordion's summary element.</p>
-      <p><button class="btn-primary">Button 1</button></p>
-      <p><button class="btn-primary">Button 2</button></p>
+      <p>A couple links are included inside this accordion to demonstrate that when the accordion is closed they are automatically not in the keyboard focus order but when the accordion opens they become the next available elements in the keyboard navigation sequence after the accordion's summary element.</p>
+      <p><a href="#nowhere1">Link 1</a></p>
+      <p><a href="#nowhere2">Link 2</a></p>
     </div>
   </details>
 </cagov-accordion>

--- a/components/accordion/template.html
+++ b/components/accordion/template.html
@@ -2,9 +2,9 @@
   <details>
     <summary>Title 1</summary>
     <div class="accordion-body">
-      <p>A couple buttons are included inside this accordion to demonstrate that when the accordion is closed they are automatically not in the keyboard focus order but when the accordion opens they become the next available elements in the keyboard navigation sequence after the accordion's summary element.</p>
-      <p><button class="btn-primary">Button 1</button></p>
-      <p><button class="btn-primary">Button 2</button></p>
+      <p>A couple links are included inside this accordion to demonstrate that when the accordion is closed they are automatically not in the keyboard focus order but when the accordion opens they become the next available elements in the keyboard navigation sequence after the accordion's summary element.</p>
+      <p><a href="#nowhere1">Link 1</a></p>
+      <p><a href="#nowhere2">Link 2</a></p>
     </div>
   </details>
 </cagov-accordion>


### PR DESCRIPTION
This change updates the accordion sample HTML so that it does not include buttons. This avoids providing a bad example because we probably don't want buttons be be inside accordions where they might be missed. Thank you @ashleydraper! Links provide the same focus example and are a better content example