### PR TITLE
Add local publishing command for yalc

### DIFF
--- a/components/accordion/package.json
+++ b/components/accordion/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "repository": {

--- a/components/back-to-top/package.json
+++ b/components/back-to-top/package.json
@@ -10,6 +10,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/base-css/package.json
+++ b/components/base-css/package.json
@@ -7,6 +7,7 @@
     "build": "sass src/themes/_cannabis.scss dist/themes/cannabis.css && sass src/themes/_drought.scss dist/themes/drought.css && sass src/themes/_cagov.scss dist/themes/cagov.css",
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "prepublishOnly": "npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/combined-css/package.json
+++ b/components/combined-css/package.json
@@ -8,6 +8,7 @@
     "build": "npm run build:js && sass --no-source-map src/_cannabis.scss dist/cannabis.css && sass --no-source-map src/_drought.scss dist/drought.css && sass --no-source-map src/_cagov.scss dist/cagov.css",
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "prepublishOnly": "npm run build && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "echo \"No test specified\" && exit 0"
   },
   "keywords": [],

--- a/components/feature-card/package.json
+++ b/components/feature-card/package.json
@@ -13,6 +13,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/highlight-section/package.json
+++ b/components/highlight-section/package.json
@@ -12,6 +12,7 @@
     "build": "sass src/index.scss dist/index.css",
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "prepublishOnly": "npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/link-grid/package.json
+++ b/components/link-grid/package.json
@@ -13,6 +13,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/link-icon/package.json
+++ b/components/link-icon/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/page-alert/package.json
+++ b/components/page-alert/package.json
@@ -10,6 +10,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/page-feedback/package.json
+++ b/components/page-feedback/package.json
@@ -14,6 +14,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "devDependencies": {

--- a/components/page-navigation/package.json
+++ b/components/page-navigation/package.json
@@ -14,6 +14,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -11,6 +11,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "devDependencies": {

--- a/components/regulatory-outline/package.json
+++ b/components/regulatory-outline/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "devDependencies": {

--- a/components/site-footer/package.json
+++ b/components/site-footer/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/site-header/package.json
+++ b/components/site-header/package.json
@@ -8,6 +8,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/site-navigation/package.json
+++ b/components/site-navigation/package.json
@@ -15,6 +15,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/skip-to-content/package.json
+++ b/components/skip-to-content/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/statewide-footer/package.json
+++ b/components/statewide-footer/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/statewide-header/package.json
+++ b/components/statewide-header/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/step-list/package.json
+++ b/components/step-list/package.json
@@ -9,6 +9,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "keywords": [],

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -10,6 +10,7 @@
     "cdn:publish": "node ../../docs/src/publish/cdn-deploy.js",
     "html:preview": "node ../../docs/src/publish/dynamic-html.js",
     "prepublishOnly": "npm run html:preview && npm run build && npm test && npm run cdn:publish",
+    "yalc:publish": "npm run build && yalc publish --no-scripts",
     "test": "web-test-runner \"test/**/*.js\" --node-resolve"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses #721 by adding a `yalc:publish` script to every component. 

I didn't want to suppress `prepublishOnly` completely, because I think it's important to include `npm run build` before publishing to yalc. Unfortunately, I didn't see a way in yalc to suppress specific npm lifecycle hooks. It's everything or nothing. So, new script to the rescue.