### PR TITLE
Add tabindex to page-navigation

### DIFF
--- a/components/page-navigation/CHANGELOG.md
+++ b/components/page-navigation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Page navigation changelog
 
+## 2.2.1
+* Fix anchor linking problem with 2.2.0 in JAWS.
+
+## 2.2.0
+* Remove polyfill for smooth scrolling in Safari.
+
 ## 2.1.3
 * Changes to how styles are inserted into the document.
 

--- a/components/page-navigation/dist/index.js
+++ b/components/page-navigation/dist/index.js
@@ -96,6 +96,7 @@ class CAGovPageNavigation extends window.HTMLElement {
       headers.forEach((tag) => {
         const tagId = tag.getAttribute('id');
         const tagName = tag.getAttribute('name');
+        const tabIndex = tag.getAttribute('tabindex') || '-1';
 
         const title = tag.innerHTML;
 
@@ -135,6 +136,7 @@ class CAGovPageNavigation extends window.HTMLElement {
 
         tag.setAttribute('id', anchor);
         tag.setAttribute('name', anchor);
+        tag.setAttribute('tabindex', tabIndex);
       });
       return `<ul>${output}</ul>`;
     }

--- a/components/page-navigation/package.json
+++ b/components/page-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-page-navigation",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/components/page-navigation/src/index.js
+++ b/components/page-navigation/src/index.js
@@ -99,6 +99,7 @@ class CAGovPageNavigation extends window.HTMLElement {
       headers.forEach((tag) => {
         const tagId = tag.getAttribute('id');
         const tagName = tag.getAttribute('name');
+        const tabIndex = tag.getAttribute('tabindex') || '-1';
 
         const title = tag.innerHTML;
 
@@ -138,6 +139,7 @@ class CAGovPageNavigation extends window.HTMLElement {
 
         tag.setAttribute('id', anchor);
         tag.setAttribute('name', anchor);
+        tag.setAttribute('tabindex', tabIndex);
       });
       return `<ul>${output}</ul>`;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,7 @@
     },
     "components/page-navigation": {
       "name": "@cagov/ds-page-navigation",
-      "version": "2.1.3",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
         "rollup-plugin-import-css": "^3.0.2"
@@ -319,7 +319,7 @@
     },
     "components/site-footer": {
       "name": "@cagov/ds-site-footer",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "@open-wc/testing": "^3.0.1",


### PR DESCRIPTION
Dynamically adds `tabindex="-1"` to headings via the page-navigation component. This fixes problems with anchor linking in the JAWS screen reader.

Fixes #931 