### PR TITLE
Version 3.0.2 of ds-site-navigation. See CHANGELOG.

### DIFF
--- a/components/site-navigation/CHANGELOG.md
+++ b/components/site-navigation/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Site navigation changelog
 
+## 3.0.2
+* Different strategy for the Android fix. Looks at prior window.innerWidth, rather than setting a flag. Fixes possible issue with multiple rapidfire calls to resize.
+
 ## 3.0.1
 * Fixed search on Android, addressing issue in #977.
 

--- a/components/site-navigation/README.md
+++ b/components/site-navigation/README.md
@@ -292,7 +292,7 @@ The instructions assume familiarity with [npm](https://npmjs.com) package manage
 We recommend using a build system and bundling your JavaScript and CSS for faster performance. If you do not use a build system, you can include the code from our CDN with link and script tags.
 
 ```html
-<link rel="stylesheet" href="https://cdn.designsystem.webstandards.ca.gov/components/ds-site-navigation/v3.0.0/dist/index.css">
+<link rel="stylesheet" href="https://cdn.designsystem.webstandards.ca.gov/components/ds-site-navigation/v3.0.2/dist/index.css">
 <script type="module" src="https://cdn.designsystem.webstandards.ca.gov/components/ds-site-navigation/v3.0.0/dist/index.js"></script>
 ```
 

--- a/components/site-navigation/dist/index.js
+++ b/components/site-navigation/dist/index.js
@@ -21,7 +21,8 @@ function mobileView() {
 }
 class CAGovSiteNavigation extends window.HTMLElement {
   connectedCallback() {
-    this.mobileSearchClicked = false;
+    // this.mobileSearchClicked = false;
+    this.priorWidth = window.innerWidth;
     document
       .querySelector('.cagov-nav.open-menu')
       .addEventListener('click', this.toggleMainMenu.bind(this));
@@ -45,10 +46,10 @@ class CAGovSiteNavigation extends window.HTMLElement {
         .setAttribute('aria-hidden', 'true');
       if (mobileView()) {
         mobileSearchBtn.addEventListener('click', () => {
-          this.mobileSearchClicked = true;
-          setTimeout(() =>{
-            this.mobileSearchClicked = false;
-          }, 3000);
+          // this.mobileSearchClicked = true;
+          // setTimeout(() =>{
+          //   this.mobileSearchClicked = false;
+          // }, 3000);
           document
             .querySelector('.search-container--small')
             .classList.toggle('hidden-search');
@@ -94,10 +95,13 @@ class CAGovSiteNavigation extends window.HTMLElement {
       // Issue #977: on Android phones, the resize event is fired when the address bar is shown/hidden
       // so we need to prevent hiding the search-bar when this occurs, otherwise, Android
       // users cannot perform a search.
-      if (this.mobileSearchClicked) { // if mobile search-icon was recently clicked, don't close it
-        this.mobileSearchClicked = false;
+      if (this.priorWidth === window.innerWidth) {
+        // width has not changed, don't reset elements
+        // this fixes an issue on Android phones, which generate
+        // extra resize events when the search bar is shown/hidden
         return;
       }
+      this.priorWidth = window.innerWidth;
       document
         .querySelector('.search-container--small')
         .classList.add('hidden-search');

--- a/components/site-navigation/package.json
+++ b/components/site-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-site-navigation",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/components/site-navigation/src/index.js
+++ b/components/site-navigation/src/index.js
@@ -21,7 +21,8 @@ function mobileView() {
 }
 class CAGovSiteNavigation extends window.HTMLElement {
   connectedCallback() {
-    this.mobileSearchClicked = false;
+    // this.mobileSearchClicked = false;
+    this.priorWidth = window.innerWidth;
     document
       .querySelector('.cagov-nav.open-menu')
       .addEventListener('click', this.toggleMainMenu.bind(this));
@@ -45,10 +46,10 @@ class CAGovSiteNavigation extends window.HTMLElement {
         .setAttribute('aria-hidden', 'true');
       if (mobileView()) {
         mobileSearchBtn.addEventListener('click', () => {
-          this.mobileSearchClicked = true;
-          setTimeout(() =>{
-            this.mobileSearchClicked = false;
-          }, 3000);
+          // this.mobileSearchClicked = true;
+          // setTimeout(() =>{
+          //   this.mobileSearchClicked = false;
+          // }, 3000);
           document
             .querySelector('.search-container--small')
             .classList.toggle('hidden-search');
@@ -94,10 +95,13 @@ class CAGovSiteNavigation extends window.HTMLElement {
       // Issue #977: on Android phones, the resize event is fired when the address bar is shown/hidden
       // so we need to prevent hiding the search-bar when this occurs, otherwise, Android
       // users cannot perform a search.
-      if (this.mobileSearchClicked) { // if mobile search-icon was recently clicked, don't close it
-        this.mobileSearchClicked = false;
+      if (this.priorWidth === window.innerWidth) {
+        // width has not changed, don't reset elements
+        // this fixes an issue on Android phones, which generate
+        // extra resize events when the search bar is shown/hidden
         return;
       }
+      this.priorWidth = window.innerWidth;
       document
         .querySelector('.search-container--small')
         .classList.add('hidden-search');


### PR DESCRIPTION
This changes the strategy used to ignore needless resizes on Android phones. Instead of using a boolean flag to detect when the mobile search-icon was pressed, it detects when the window's innerWidth has changed, and if not, it does not reset the search elements.  Code is a bit simpler, and this will consistently work if multiple resize events are generated.