### PR TITLE
Pagination display fix.  @cagov/ds-pagination version 2.0.4

### DIFF
--- a/components/pagination/CHANGELOG.md
+++ b/components/pagination/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Pagination changelog
 
 ## 2.0.3
+- Fixes an issue with small page counts (4,5,6,7) in which on some page numbers
+an ellipsis is displayed where a single-page is missing, or both the ellipsis and
+a single page are skipped leaving a gap in the sequence. New system uses ellipsis for
+2 or more pages only, and displays single pages in its place, when appropriate.
+
+## 2.0.3
 
 - Removed redundant package-lock.json (due to workspaces config in monorepo). This fixes vulnerability in the npm `ip` package.
 - Fixed an accessibility issue with accessibility of the ellipsis-based "overflow". 

--- a/components/pagination/CHANGELOG.md
+++ b/components/pagination/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pagination changelog
 
-## 2.0.3
+## 2.0.4
 - Fixes an issue with small page counts (4,5,6,7) in which on some page numbers
 an ellipsis is displayed where a single-page is missing, or both the ellipsis and
 a single page are skipped leaving a gap in the sequence. New system uses ellipsis for

--- a/components/pagination/dist/index.js
+++ b/components/pagination/dist/index.js
@@ -35,7 +35,7 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       </li>
       ${currentPage > 2 ? pageListItem(page, 1) : ''}
 
-      ${currentPage > 4 ? pageOverflow() :  ''}
+      ${currentPage > 4 ? pageOverflow() : ''}
       ${currentPage === 4 ? pageListItem(page, 2) : ''}
 
       ${currentPage > 1 ? pageListItem(page, currentPage - 1) : ''}
@@ -55,7 +55,9 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       ${currentPage < totalPages ? pageListItem(page, currentPage + 1) : ''}
 
       ${currentPage < totalPages - 3 ? pageOverflow() : ''}
-      ${currentPage === totalPages - 3 ? pageListItem(page, totalPages-1) : ''}
+      ${
+        currentPage === totalPages - 3 ? pageListItem(page, totalPages - 1) : ''
+      }
 
       ${currentPage < totalPages - 1 ? pageListItem(page, totalPages) : ''}
 

--- a/components/pagination/dist/index.js
+++ b/components/pagination/dist/index.js
@@ -35,7 +35,8 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       </li>
       ${currentPage > 2 ? pageListItem(page, 1) : ''}
 
-      ${currentPage > 3 ? pageOverflow() : ''}
+      ${currentPage > 4 ? pageOverflow() :  ''}
+      ${currentPage === 4 ? pageListItem(page, 2) : ''}
 
       ${currentPage > 1 ? pageListItem(page, currentPage - 1) : ''}
 
@@ -54,6 +55,7 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       ${currentPage < totalPages ? pageListItem(page, currentPage + 1) : ''}
 
       ${currentPage < totalPages - 3 ? pageOverflow() : ''}
+      ${currentPage === totalPages - 3 ? pageListItem(page, totalPages-1) : ''}
 
       ${currentPage < totalPages - 1 ? pageListItem(page, totalPages) : ''}
 

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/ds-pagination",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "",
   "main": "dist/index.js",
   "customElements": "custom-elements.json",

--- a/components/pagination/src/template.js
+++ b/components/pagination/src/template.js
@@ -35,7 +35,7 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       </li>
       ${currentPage > 2 ? pageListItem(page, 1) : ''}
 
-      ${currentPage > 4 ? pageOverflow() :  ''}
+      ${currentPage > 4 ? pageOverflow() : ''}
       ${currentPage === 4 ? pageListItem(page, 2) : ''}
 
       ${currentPage > 1 ? pageListItem(page, currentPage - 1) : ''}
@@ -55,7 +55,9 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       ${currentPage < totalPages ? pageListItem(page, currentPage + 1) : ''}
 
       ${currentPage < totalPages - 3 ? pageOverflow() : ''}
-      ${currentPage === totalPages - 3 ? pageListItem(page, totalPages-1) : ''}
+      ${
+        currentPage === totalPages - 3 ? pageListItem(page, totalPages - 1) : ''
+      }
 
       ${currentPage < totalPages - 1 ? pageListItem(page, totalPages) : ''}
 

--- a/components/pagination/src/template.js
+++ b/components/pagination/src/template.js
@@ -35,7 +35,8 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       </li>
       ${currentPage > 2 ? pageListItem(page, 1) : ''}
 
-      ${currentPage > 3 ? pageOverflow() : ''}
+      ${currentPage > 4 ? pageOverflow() :  ''}
+      ${currentPage === 4 ? pageListItem(page, 2) : ''}
 
       ${currentPage > 1 ? pageListItem(page, currentPage - 1) : ''}
 
@@ -54,6 +55,7 @@ function templateHTML(next, previous, page, currentPage, totalPages) {
       ${currentPage < totalPages ? pageListItem(page, currentPage + 1) : ''}
 
       ${currentPage < totalPages - 3 ? pageOverflow() : ''}
+      ${currentPage === totalPages - 3 ? pageListItem(page, totalPages-1) : ''}
 
       ${currentPage < totalPages - 1 ? pageListItem(page, totalPages) : ''}
 


### PR DESCRIPTION
This fixes a display issue with pagination buttons.  The current code displays the following when there are 4 available pages.

![CleanShot 2024-08-15 at 14 01 36](https://github.com/user-attachments/assets/8875b7a7-51c0-401d-9c4b-553a92ded220)

Notice that on page 1, Page 3 is mysteriously dropped.    On Page 4, an ellipsis is displayed in place of a single page (ellipsis should only be used for 2 or more pages).

There are similar issues with 5 page, 6 page, and 7 page displays.  Here is a 7 page display.
![CleanShot 2024-08-15 at 14 02 58](https://github.com/user-attachments/assets/37b63b1a-0a95-4d01-8843-3a2fd5ec2495)
Notice that an ellipsis is shown in place of a single page, and page 6 is missing.

This patch shows the ellipsis in cases where it represents 2 or more pages, and shows a single page in its place, when it is appropriate to do, fixing all the above issues.